### PR TITLE
Add SendArtnet job

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
+        "artnet": "^1.4.0",
         "dotenv": "^16.5.0",
         "ip": "^2.0.1",
         "middleware": "^1.0.0",
@@ -2335,6 +2336,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/artnet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/artnet/-/artnet-1.4.0.tgz",
+      "integrity": "sha512-5s/1DRr+qidggUwslxiGvY3ZHPIuYUfLKgcqv4MbODwjq4ipTWqr6gOfSqRfdNEGjIkzIQ6M0V4ukFbCwBMjKQ==",
+      "license": "MIT"
     },
     "node_modules/assert-plus": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:unit": "vitest src"
   },
   "dependencies": {
+    "artnet": "^1.4.0",
     "dotenv": "^16.5.0",
     "ip": "^2.0.1",
     "middleware": "^1.0.0",

--- a/src/app/src/domain/entities/job/types/index.ts
+++ b/src/app/src/domain/entities/job/types/index.ts
@@ -1,10 +1,12 @@
 export default {
     sendUDPJob: await import("./sendUDP/index.js"),
+    sendArtnetJob: await import("./sendArtnet/index.js"),
     waitJob: await import("./wait/index.js"),
-} 
+}
 
 export const jobTypes = {
     sendUDPJob: "sendUDPJob",
     sendTCPJob: "sendTCPJob",
+    sendArtnetJob: "sendArtnetJob",
     waitJob: "waitJob",
 }

--- a/src/app/src/domain/entities/job/types/sendArtnet/index.ts
+++ b/src/app/src/domain/entities/job/types/sendArtnet/index.ts
@@ -1,0 +1,103 @@
+import { JobType } from "@common/types/job.type";
+import { Job } from "../..";
+import artnet from "artnet";
+import jobEvents from "@common/events/job.events";
+import { jobTypes } from "..";
+
+interface SendArtnetJobParams extends JobType {
+    // Optional host and port can be provided
+    params: {
+        channel: number;
+        universe: number;
+        value: number;
+        host?: string;
+        port?: number;
+    } & Record<string, any>;
+}
+
+export class SendArtnetJob extends Job {
+    constructor(options: SendArtnetJobParams) {
+        super({
+            ...options,
+            timeout: 5000,
+            enableTimoutWatcher: true,
+            type: jobTypes.sendArtnetJob,
+        });
+    }
+
+    #getParameters(): Record<string, any> {
+        const params = this.params || {};
+        const expectedParams = ["channel", "universe", "value"];
+        const missingParams = expectedParams.filter(p => !(p in params));
+        if (missingParams.length > 0)
+            throw new Error(`Missing required parameters: ${missingParams.join(", ")}`);
+
+        if (typeof params.channel !== "number" || params.channel < 1 || params.channel > 512)
+            throw new Error("channel must be a number between 1 and 512");
+
+        if (typeof params.universe !== "number" || params.universe < 0 || params.universe > 65535)
+            throw new Error("universe must be a number between 0 and 65535");
+
+        if (typeof params.value !== "number" || params.value < 0 || params.value > 255)
+            throw new Error("value must be a number between 0 and 255");
+
+        if (params.host && typeof params.host !== "string")
+            throw new Error("host must be a string");
+
+        if (params.port && (typeof params.port !== "number" || params.port < 0 || params.port > 65535))
+            throw new Error("port must be a number between 0 and 65535");
+
+        return params as Record<string, any>;
+    }
+
+    async job(): Promise<void> {
+        this.failed = false;
+        const { signal: abortSignal } = this.abortController || {};
+        this.log.info(`Starting job "${this.name}" with ID ${this.id}`);
+
+        let channel: number, universe: number, value: number, host: string | undefined, port: number | undefined;
+
+        try {
+            ({ channel, universe, value, host, port } = this.#getParameters());
+        } catch (error) {
+            this.failed = true;
+            this.dispatchEvent(jobEvents.jobError, { jobId: this.id, error });
+            throw error;
+        }
+
+        const client = artnet({ host: host || "255.255.255.255", port });
+
+        return new Promise<void>((resolve, reject) => {
+            const finish = (err?: Error) => {
+                client.close();
+                if (err) {
+                    this.failed = true;
+                    this.dispatchEvent(jobEvents.jobError, { jobId: this.id, error: err });
+                    reject(err);
+                } else {
+                    resolve();
+                }
+            };
+
+            client.set(universe, channel, value, (err: Error | null) => {
+                if (err) {
+                    this.log.error(`Failed to send ArtNet packet: ${err.message}`);
+                    finish(err);
+                } else {
+                    this.log.info(`ArtNet packet sent to universe ${universe} channel ${channel}`);
+                    finish();
+                }
+            });
+
+            if (abortSignal) {
+                abortSignal.addEventListener("abort", () => {
+                    finish(new Error(`Job \"${this.name}\" was aborted`));
+                });
+            }
+        }).finally(() => {
+            this.log.info(`Job \"${this.name}\" with ID ${this.id} has finished`);
+            this.dispatchEvent(jobEvents.jobFinished, { jobId: this.id, failed: this.failed });
+        });
+    }
+}
+

--- a/src/app/src/domain/entities/job/types/sendArtnet/sendArtnet.Job.test.ts
+++ b/src/app/src/domain/entities/job/types/sendArtnet/sendArtnet.Job.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import dgram from 'dgram';
+import { SendArtnetJob } from '.';
+
+describe('SendArtnetJob (integration)', () => {
+  let server: dgram.Socket;
+  let messages: Buffer[];
+  const PORT = 6454;
+  const HOST = '127.0.0.1';
+
+  beforeAll(() => {
+    messages = [];
+    server = dgram.createSocket('udp4');
+    server.on('message', (msg) => messages.push(msg));
+    return new Promise<void>((resolve) => server.bind(PORT, HOST, resolve));
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('should send an ArtNet packet with correct value', async () => {
+    const job = new SendArtnetJob({
+      name: 'Test Artnet Job',
+      params: { channel: 1, universe: 0, value: 50, host: HOST, port: PORT }
+    });
+    await job.execute({ abortSignal: new AbortController().signal });
+    await new Promise((res) => setTimeout(res, 100));
+    expect(messages.length).toBeGreaterThan(0);
+    const buf = messages[0];
+    const receivedUniverse = buf[14] + (buf[15] << 8);
+    const receivedValue = buf[18];
+    expect(receivedUniverse).toBe(0);
+    expect(receivedValue).toBe(50);
+  });
+
+  it('should abort the job', async () => {
+    const job = new SendArtnetJob({
+      name: 'Abort Artnet Job',
+      params: { channel: 1, universe: 0, value: 10, host: HOST, port: PORT }
+    });
+    const ac = new AbortController();
+    ac.abort();
+    await expect(job.execute({ abortSignal: ac.signal })).rejects.toThrow('Job "Abort Artnet Job" was aborted');
+  });
+
+  it('should validate required parameters', async () => {
+    const job = new SendArtnetJob({
+      name: 'Invalid',
+      params: { universe: 0, value: 10 } as any
+    });
+    await expect(job.execute({ abortSignal: new AbortController().signal })).rejects.toThrow('Missing required parameters: channel');
+  });
+});


### PR DESCRIPTION
## Summary
- add `artnet` dependency
- implement `SendArtnetJob` for sending DMX values using artnet
- export the job in job types registry
- create integration tests for the new job

## Testing
- `npm run test:unit --silent` *(fails: sendUDP broadcast test fails due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6840b86791e08327a2c18c2af899f28b