### PR TITLE
Add TcpTrigger and UdpTrigger

### DIFF
--- a/src/app/src/domain/entities/trigger/types/index.ts
+++ b/src/app/src/domain/entities/trigger/types/index.ts
@@ -1,4 +1,5 @@
-
 export const TriggerTypes = {
     cron: "cron",
+    tcp: "tcp",
+    udp: "udp",
 } as const;

--- a/src/app/src/domain/entities/trigger/types/tcp/index.ts
+++ b/src/app/src/domain/entities/trigger/types/tcp/index.ts
@@ -1,0 +1,68 @@
+import net from 'net';
+import { Trigger } from '../..';
+import triggerEvents from '@common/events/trigger.events';
+import { TriggerType } from '@common/types/trigger.type';
+import { TriggerTypes } from '..';
+
+interface TcpTriggerOptions extends TriggerType {
+    port: number;
+    ip?: string;
+    message: string;
+}
+
+export class TcpTrigger extends Trigger {
+    static type = 'tcp';
+    port: number;
+    ip: string;
+    expectedMessage: string;
+    server?: net.Server;
+
+    constructor(options: TcpTriggerOptions) {
+        super({
+            ...options,
+            type: TriggerTypes.tcp,
+            name: options.name || 'TCP Trigger',
+            description: options.description || 'Trigger that listens for TCP messages',
+        });
+
+        if (typeof options.port !== 'number' || options.port <= 0 || options.port > 65535)
+            throw new Error('Invalid port: must be between 1 and 65535');
+        this.port = options.port;
+
+        const ipMask = /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+        if (options.ip && !ipMask.test(options.ip))
+            throw new Error('Invalid ip address');
+        this.ip = options.ip || '0.0.0.0';
+
+        if (!options.message || typeof options.message !== 'string')
+            throw new Error('Message must be a string');
+        this.expectedMessage = options.message;
+
+        this.on(triggerEvents.triggerArmed, this.init.bind(this));
+        this.on(triggerEvents.triggerDisarmed, this.destroy.bind(this));
+    }
+
+    private init() {
+        if (this.server)
+            return;
+        this.server = net.createServer(socket => {
+            socket.on('data', data => {
+                const msg = data.toString();
+                if (msg.trim() === this.expectedMessage) {
+                    this.trigger();
+                }
+            });
+        });
+        this.server.listen(this.port, this.ip, () => {
+            this.logger.info(`TCP Trigger listening on ${this.ip}:${this.port}`);
+        });
+    }
+
+    async destroy() {
+        if (this.server) {
+            this.server.close();
+            this.server = undefined;
+            this.logger.info('TCP Trigger server closed');
+        }
+    }
+}

--- a/src/app/src/domain/entities/trigger/types/tcp/tcp.trigger.test.ts
+++ b/src/app/src/domain/entities/trigger/types/tcp/tcp.trigger.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import net from 'net';
+import { TcpTrigger } from './';
+import triggerEvents from '@common/events/trigger.events';
+
+const TEST_PORT = 40100;
+
+describe('TcpTrigger Tests', () => {
+    it('should trigger on receiving the expected message', async () => {
+        const trigger = new TcpTrigger({ port: TEST_PORT, message: 'ping' });
+        trigger.arm();
+
+        await new Promise<void>((resolve, reject) => {
+            trigger.on(triggerEvents.triggered, () => {
+                try {
+                    expect(trigger.triggered).toBe(true);
+                    resolve();
+                } catch (err) {
+                    reject(err);
+                }
+            });
+
+            const client = new net.Socket();
+            client.connect(TEST_PORT, '127.0.0.1', () => {
+                client.write('ping');
+                client.end();
+            });
+        });
+
+        trigger.disarm();
+    });
+});

--- a/src/app/src/domain/entities/trigger/types/udp/index.ts
+++ b/src/app/src/domain/entities/trigger/types/udp/index.ts
@@ -1,0 +1,67 @@
+import dgram from 'dgram';
+import { Trigger } from '../..';
+import triggerEvents from '@common/events/trigger.events';
+import { TriggerType } from '@common/types/trigger.type';
+import { TriggerTypes } from '..';
+
+interface UdpTriggerOptions extends TriggerType {
+    port: number;
+    ip?: string;
+    message: string;
+}
+
+export class UdpTrigger extends Trigger {
+    static type = 'udp';
+    port: number;
+    ip: string;
+    expectedMessage: string;
+    server?: dgram.Socket;
+
+    constructor(options: UdpTriggerOptions) {
+        super({
+            ...options,
+            type: TriggerTypes.udp,
+            name: options.name || 'UDP Trigger',
+            description: options.description || 'Trigger that listens for UDP messages',
+        });
+
+        if (typeof options.port !== 'number' || options.port <= 0 || options.port > 65535)
+            throw new Error('Invalid port: must be between 1 and 65535');
+        this.port = options.port;
+
+        const ipMask = /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+        if (options.ip && !ipMask.test(options.ip))
+            throw new Error('Invalid ip address');
+        this.ip = options.ip || '0.0.0.0';
+
+        if (!options.message || typeof options.message !== 'string')
+            throw new Error('Message must be a string');
+        this.expectedMessage = options.message;
+
+        this.on(triggerEvents.triggerArmed, this.init.bind(this));
+        this.on(triggerEvents.triggerDisarmed, this.destroy.bind(this));
+    }
+
+    private init() {
+        if (this.server)
+            return;
+        this.server = dgram.createSocket('udp4');
+        this.server.on('message', msg => {
+            const data = msg.toString();
+            if (data.trim() === this.expectedMessage) {
+                this.trigger();
+            }
+        });
+        this.server.bind(this.port, this.ip, () => {
+            this.logger.info(`UDP Trigger listening on ${this.ip}:${this.port}`);
+        });
+    }
+
+    async destroy() {
+        if (this.server) {
+            this.server.close();
+            this.server = undefined;
+            this.logger.info('UDP Trigger socket closed');
+        }
+    }
+}

--- a/src/app/src/domain/entities/trigger/types/udp/udp.trigger.test.ts
+++ b/src/app/src/domain/entities/trigger/types/udp/udp.trigger.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import dgram from 'dgram';
+import { UdpTrigger } from './';
+import triggerEvents from '@common/events/trigger.events';
+
+const TEST_PORT = 40101;
+
+describe('UdpTrigger Tests', () => {
+    it('should trigger on receiving the expected message', async () => {
+        const trigger = new UdpTrigger({ port: TEST_PORT, message: 'ping' });
+        trigger.arm();
+
+        await new Promise<void>((resolve, reject) => {
+            trigger.on(triggerEvents.triggered, () => {
+                try {
+                    expect(trigger.triggered).toBe(true);
+                    resolve();
+                } catch (err) {
+                    reject(err);
+                }
+            });
+
+            const client = dgram.createSocket('udp4');
+            client.send(Buffer.from('ping'), TEST_PORT, '127.0.0.1', () => {
+                client.close();
+            });
+        });
+
+        trigger.disarm();
+    });
+});


### PR DESCRIPTION
## Summary
- add `TcpTrigger` and `UdpTrigger`
- register new trigger types
- test TCP and UDP triggers

## Testing
- `npm run test:unit` *(fails: Test Files 2 failed | 6 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6851ba1125b88327a76aa95abe155058