### PR TITLE
Add OnRoutineEvent trigger

### DIFF
--- a/src/app/src/domain/entities/trigger/types/index.ts
+++ b/src/app/src/domain/entities/trigger/types/index.ts
@@ -2,4 +2,5 @@ export const TriggerTypes = {
     cron: "cron",
     tcp: "tcp",
     udp: "udp",
+    onRoutineEvent: "onRoutineEvent",
 } as const;

--- a/src/app/src/domain/entities/trigger/types/onRoutineEvent/index.ts
+++ b/src/app/src/domain/entities/trigger/types/onRoutineEvent/index.ts
@@ -1,0 +1,75 @@
+import { Trigger } from '../..';
+import { TriggerType } from '@common/types/trigger.type';
+import { TriggerTypes } from '..';
+import triggerEvents from '@common/events/trigger.events';
+import routineEvents from '@common/events/routine.events';
+import { EventManager } from '@services/eventManager';
+import { RoutineActions } from '@src/domain/entities/routine';
+
+interface OnRoutineEventTriggerOptions extends TriggerType {
+    routineId: string;
+    routineEvent: RoutineActions;
+}
+
+export class OnRoutineEventTrigger extends Trigger {
+    static type = 'onRoutineEvent';
+    routineId: string;
+    routineEvent: RoutineActions;
+    private eventManager: EventManager;
+    private boundHandler: ((payload: any) => void) | null = null;
+
+    constructor(options: OnRoutineEventTriggerOptions) {
+        super({
+            ...options,
+            type: TriggerTypes.onRoutineEvent,
+            name: options.name || 'OnRoutineEvent Trigger',
+            description: options.description || 'Trigger that listens for routine events',
+        });
+
+        if (!options.routineId || typeof options.routineId !== 'string')
+            throw new Error('routineId must be a string');
+        this.routineId = options.routineId;
+
+        if (!RoutineActions.includes(options.routineEvent))
+            throw new Error(`routineEvent must be one of: ${RoutineActions.join(', ')}`);
+        this.routineEvent = options.routineEvent;
+
+        this.eventManager = new EventManager();
+
+        this.on(triggerEvents.triggerArmed, this.init.bind(this));
+        this.on(triggerEvents.triggerDisarmed, this.destroy.bind(this));
+    }
+
+    #mapEvent(action: RoutineActions): string {
+        switch (action) {
+            case 'enable':
+                return routineEvents.routineEnabled;
+            case 'disable':
+                return routineEvents.routineDisabled;
+            case 'run':
+                return routineEvents.routineRunning;
+            case 'stop':
+                return routineEvents.routineAborted;
+            default:
+                return '';
+        }
+    }
+
+    private init() {
+        if (this.boundHandler) return;
+        const eventName = this.#mapEvent(this.routineEvent);
+        this.boundHandler = (payload: any) => {
+            if (payload?.routineId === this.routineId) {
+                this.trigger();
+            }
+        };
+        this.eventManager.on(eventName, this.boundHandler);
+    }
+
+    private destroy() {
+        if (!this.boundHandler) return;
+        const eventName = this.#mapEvent(this.routineEvent);
+        this.eventManager.off(eventName, this.boundHandler);
+        this.boundHandler = null;
+    }
+}

--- a/src/app/src/domain/entities/trigger/types/onRoutineEvent/onRoutineEvent.trigger.test.ts
+++ b/src/app/src/domain/entities/trigger/types/onRoutineEvent/onRoutineEvent.trigger.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { OnRoutineEventTrigger } from './';
+import { EventManager } from '@services/eventManager';
+import triggerEvents from '@common/events/trigger.events';
+import routineEvents from '@common/events/routine.events';
+
+const ROUTINE_ID = 'routine-test';
+
+describe('OnRoutineEventTrigger', () => {
+    it('should trigger when matching routine event occurs', async () => {
+        const trigger = new OnRoutineEventTrigger({ routineId: ROUTINE_ID, routineEvent: 'run', name: 'Test Trigger' });
+        trigger.arm();
+        const eventManager = new EventManager();
+
+        await new Promise<void>((resolve, reject) => {
+            trigger.on(triggerEvents.triggered, () => {
+                try {
+                    expect(trigger.triggered).toBe(true);
+                    resolve();
+                } catch (err) {
+                    reject(err);
+                }
+            });
+            eventManager.emit(routineEvents.routineRunning, { routineId: ROUTINE_ID });
+        });
+
+        trigger.disarm();
+    });
+
+    it('should not trigger when routine id does not match', async () => {
+        const trigger = new OnRoutineEventTrigger({ routineId: ROUTINE_ID, routineEvent: 'run', name: 'Test Trigger' });
+        trigger.arm();
+        const eventManager = new EventManager();
+        eventManager.emit(routineEvents.routineRunning, { routineId: 'other' });
+        await new Promise(resolve => setTimeout(resolve, 100));
+        expect(trigger.triggered).toBe(false);
+        trigger.disarm();
+    });
+});


### PR DESCRIPTION
## Summary
- add new trigger `OnRoutineEvent`
- wire it into available trigger types
- test `OnRoutineEvent` trigger

## Testing
- `npm run test:unit` *(fails: ENETUNREACH when running network dependent tests)*

------
https://chatgpt.com/codex/tasks/task_e_6851cb13cab88327995a221be19e5c6c