### PR TITLE
Add ConditionPing

### DIFF
--- a/src/app/src/domain/entities/conditions/types/ping/condition.ping.test.ts
+++ b/src/app/src/domain/entities/conditions/types/ping/condition.ping.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import ConditionPing from './index';
+
+describe('ConditionPing', () => {
+    it('should resolve true when pinging localhost', async () => {
+        const condition = new ConditionPing({ ip: '127.0.0.1', name: 'Ping Localhost' });
+        const result = await condition.evaluate({ abortSignal: new AbortController().signal });
+        expect(result).toBe(true);
+    });
+
+    it('should throw an error for invalid ip', () => {
+        expect(() => new ConditionPing({ ip: 'invalid-ip', name: 'Invalid' })).toThrow('Ip address must be a valid IPv4 address');
+    });
+
+    it('should return false if aborted before evaluation', async () => {
+        const condition = new ConditionPing({ ip: '127.0.0.1' });
+        const controller = new AbortController();
+        controller.abort();
+        const result = await condition.evaluate({ abortSignal: controller.signal });
+        expect(result).toBe(false);
+    });
+});

--- a/src/app/src/domain/entities/conditions/types/ping/index.ts
+++ b/src/app/src/domain/entities/conditions/types/ping/index.ts
@@ -1,0 +1,51 @@
+import { Condition } from "../..";
+import { ConditionType } from "@common/types/condition.type";
+import { exec } from "child_process";
+
+interface ConditionPingParams extends Partial<ConditionType> {
+    ip: string;
+    timeoutValue?: number;
+}
+
+export class ConditionPing extends Condition {
+    ip: string;
+    static type = "ping";
+
+    constructor(options: ConditionPingParams) {
+        super({
+            ...options,
+            type: ConditionPing.type,
+            name: options.name || "Ping Condition",
+            description: options.description || "Condition that pings an IP",
+            timeoutValue: options.timeoutValue
+        } as ConditionType);
+
+        const ipMask = /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+        if (!options.ip || typeof options.ip !== "string" || !ipMask.test(options.ip))
+            throw new Error("Ip address must be a valid IPv4 address");
+        this.ip = options.ip;
+    }
+
+    protected async doEvaluation({ abortSignal }: { abortSignal: AbortSignal }): Promise<boolean> {
+        if (abortSignal.aborted) {
+            return Promise.reject(new Error("Condition evaluation aborted"));
+        }
+
+        return new Promise((resolve, reject) => {
+            const command = process.platform === "win32" ? `ping -n 1 ${this.ip}` : `ping -c 1 ${this.ip}`;
+            const child = exec(command, (error) => {
+                if (error) {
+                    return reject(error);
+                }
+                resolve(true);
+            });
+
+            abortSignal.addEventListener("abort", () => {
+                child.kill();
+                reject(new Error("Condition evaluation aborted"));
+            });
+        });
+    }
+}
+
+export default ConditionPing;


### PR DESCRIPTION
## Summary
- implement ConditionPing to ping an IP address
- add tests for ConditionPing

## Testing
- `npx vitest run src/app/src/domain/entities/conditions/types/ping/condition.ping.test.ts`
- `npm run test:unit` *(fails: sendUDP broadcast & udp trigger broadcast tests)*

------
https://chatgpt.com/codex/tasks/task_e_6851ec395c9883279cc6952256c3292e