### PR TITLE
Add additional conditions

### DIFF
--- a/src/app/src/domain/entities/conditions/types/dayTime/condition.dayTime.test.ts
+++ b/src/app/src/domain/entities/conditions/types/dayTime/condition.dayTime.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import ConditionDayTime from './index';
+
+describe('ConditionDayTime', () => {
+    const now = new Date();
+
+    it('should resolve true when current time matches parameters', async () => {
+        const condition = new ConditionDayTime({
+            day: now.getDay(),
+            hour: now.getHours(),
+            minute: now.getMinutes()
+        });
+        const result = await condition.evaluate({ abortSignal: new AbortController().signal });
+        expect(result).toBe(true);
+    });
+
+    it('should return false when day does not match', async () => {
+        const wrongDay = (now.getDay() + 1) % 7;
+        const condition = new ConditionDayTime({ day: wrongDay });
+        const result = await condition.evaluate({ abortSignal: new AbortController().signal });
+        expect(result).toBe(false);
+    });
+
+    it('should throw an error if no parameters are provided', () => {
+        // @ts-expect-error
+        expect(() => new ConditionDayTime({})).toThrow('At least one of day, hour or minute must be specified');
+    });
+
+    it('should return false if aborted before evaluation', async () => {
+        const condition = new ConditionDayTime({ day: now.getDay() });
+        const controller = new AbortController();
+        controller.abort();
+        const result = await condition.evaluate({ abortSignal: controller.signal });
+        expect(result).toBe(false);
+    });
+});

--- a/src/app/src/domain/entities/conditions/types/dayTime/index.ts
+++ b/src/app/src/domain/entities/conditions/types/dayTime/index.ts
@@ -1,0 +1,71 @@
+import { Condition } from "../..";
+import { ConditionType } from "@common/types/condition.type";
+
+interface ConditionDayTimeParams extends Partial<ConditionType> {
+    day?: number;
+    hour?: number;
+    minute?: number;
+    timeoutValue?: number;
+}
+
+export class ConditionDayTime extends Condition {
+    static type = "dayTime";
+    day?: number;
+    hour?: number;
+    minute?: number;
+
+    constructor(options: ConditionDayTimeParams) {
+        super({
+            ...options,
+            type: ConditionDayTime.type,
+            name: options.name || "Day Time Condition",
+            description: options.description || "Condition that checks day and time",
+            timeoutValue: options.timeoutValue
+        } as ConditionType);
+
+        if (options.day === undefined && options.hour === undefined && options.minute === undefined) {
+            throw new Error("At least one of day, hour or minute must be specified");
+        }
+
+        if (options.day !== undefined) {
+            if (typeof options.day !== 'number' || options.day < 0 || options.day > 6) {
+                throw new Error("day must be a number between 0 and 6");
+            }
+            this.day = options.day;
+        }
+
+        if (options.hour !== undefined) {
+            if (typeof options.hour !== 'number' || options.hour < 0 || options.hour > 23) {
+                throw new Error("hour must be a number between 0 and 23");
+            }
+            this.hour = options.hour;
+        }
+
+        if (options.minute !== undefined) {
+            if (typeof options.minute !== 'number' || options.minute < 0 || options.minute > 59) {
+                throw new Error("minute must be a number between 0 and 59");
+            }
+            this.minute = options.minute;
+        }
+    }
+
+    protected async doEvaluation({ abortSignal }: { abortSignal: AbortSignal }): Promise<boolean> {
+        return new Promise((resolve, reject) => {
+            if (abortSignal.aborted) {
+                return reject(new Error("Condition evaluation aborted"));
+            }
+            const now = new Date();
+            const dayMatch = this.day === undefined || now.getDay() === this.day;
+            const hourMatch = this.hour === undefined || now.getHours() === this.hour;
+            const minuteMatch = this.minute === undefined || now.getMinutes() === this.minute;
+
+            if (dayMatch && hourMatch && minuteMatch) {
+                resolve(true);
+            } else {
+                reject(new Error("Condition not met"));
+            }
+        });
+    }
+}
+
+export default ConditionDayTime;

--- a/src/app/src/domain/entities/conditions/types/info.txt
+++ b/src/app/src/domain/entities/conditions/types/info.txt
@@ -2,6 +2,6 @@
 require:
 
 * Ping: debe realizar unping
-* Time
+* DayTime
 * TCP Answer
 * UDP Answer

--- a/src/app/src/domain/entities/conditions/types/tcpAnswer/condition.tcpAnswer.test.ts
+++ b/src/app/src/domain/entities/conditions/types/tcpAnswer/condition.tcpAnswer.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import ConditionTCPAnswer from './index';
+import net from 'net';
+
+describe('ConditionTCPAnswer', () => {
+    let server: net.Server;
+    beforeAll(() => {
+        server = net.createServer(socket => {
+            socket.on('data', data => {
+                const msg = data.toString();
+                const response = msg.includes('Hello') ? 'Ack' : 'No';
+                socket.write(response);
+            });
+        });
+        return new Promise<void>(resolve => server.listen(34567, '127.0.0.1', resolve));
+    });
+
+    afterAll(() => {
+        server.close();
+    });
+
+    it('should resolve true when expected answer is received', async () => {
+        const condition = new ConditionTCPAnswer({ ip: '127.0.0.1', port: 34567, message: 'Hello', answer: 'Ack' });
+        const result = await condition.evaluate({ abortSignal: new AbortController().signal });
+        expect(result).toBe(true);
+    });
+
+    it('should return false if aborted before evaluation', async () => {
+        const condition = new ConditionTCPAnswer({ ip: '127.0.0.1', port: 34567, message: 'Hello', answer: 'Ack' });
+        const controller = new AbortController();
+        controller.abort();
+        const result = await condition.evaluate({ abortSignal: controller.signal });
+        expect(result).toBe(false);
+    });
+
+    it('should throw an error for invalid ip', () => {
+        expect(() => new ConditionTCPAnswer({ ip: 'invalid-ip', port: 1, message: 'hi', answer: 'a' })).toThrow('Ip address must be a valid IPv4 address');
+    });
+});

--- a/src/app/src/domain/entities/conditions/types/tcpAnswer/index.ts
+++ b/src/app/src/domain/entities/conditions/types/tcpAnswer/index.ts
@@ -1,0 +1,80 @@
+import { Condition } from "../..";
+import { ConditionType } from "@common/types/condition.type";
+import net from 'net';
+
+interface ConditionTCPAnswerParams extends Partial<ConditionType> {
+    ip: string;
+    port: number;
+    message: string;
+    answer: string;
+    timeoutValue?: number;
+}
+
+export class ConditionTCPAnswer extends Condition {
+    static type = "tcpAnswer";
+    ip: string;
+    port: number;
+    message: string;
+    answer: string;
+
+    constructor(options: ConditionTCPAnswerParams) {
+        super({
+            ...options,
+            type: ConditionTCPAnswer.type,
+            name: options.name || "TCP Answer Condition",
+            description: options.description || "Condition that waits for a TCP answer",
+            timeoutValue: options.timeoutValue
+        } as ConditionType);
+
+        const ipMask = /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+        if (!options.ip || !ipMask.test(options.ip))
+            throw new Error("Ip address must be a valid IPv4 address");
+        if (typeof options.port !== 'number' || options.port < 0 || options.port > 65535)
+            throw new Error("Port must be a number between 0 and 65535");
+        if (!options.message || typeof options.message !== 'string')
+            throw new Error("Message must be a string");
+        if (!options.answer || typeof options.answer !== 'string')
+            throw new Error("Answer must be a string");
+
+        this.ip = options.ip;
+        this.port = options.port;
+        this.message = options.message;
+        this.answer = options.answer;
+    }
+
+    protected async doEvaluation({ abortSignal }: { abortSignal: AbortSignal }): Promise<boolean> {
+        return new Promise((resolve, reject) => {
+            const client = new net.Socket();
+            const onAbort = () => {
+                client.destroy();
+                reject(new Error("Condition evaluation aborted"));
+            };
+
+            if (abortSignal.aborted) return onAbort();
+
+            abortSignal.addEventListener("abort", onAbort, { once: true });
+
+            client.connect(this.port, this.ip, () => {
+                client.write(this.message);
+            });
+
+            client.on('data', (data: Buffer) => {
+                const response = data.toString();
+                this.logger.info('Received:', response);
+                if (response === this.answer) {
+                    abortSignal.removeEventListener("abort", onAbort);
+                    client.destroy();
+                    resolve(true);
+                }
+            });
+
+            client.on('error', (err) => {
+                abortSignal.removeEventListener("abort", onAbort);
+                client.destroy();
+                reject(err);
+            });
+        });
+    }
+}
+
+export default ConditionTCPAnswer;

--- a/src/app/src/domain/entities/conditions/types/udpAnswer/condition.udpAnswer.test.ts
+++ b/src/app/src/domain/entities/conditions/types/udpAnswer/condition.udpAnswer.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import ConditionUDPAnswer from './index';
+import dgram from 'dgram';
+
+describe('ConditionUDPAnswer', () => {
+    let server: dgram.Socket;
+    beforeAll(() => {
+        server = dgram.createSocket('udp4');
+        server.on('message', (msg, rinfo) => {
+            const message = msg.toString();
+            const response = message.includes('Hello') ? 'Ack' : 'No';
+            server.send(response, rinfo.port, rinfo.address);
+        });
+        return new Promise<void>(resolve => server.bind(34568, '127.0.0.1', resolve));
+    });
+
+    afterAll(() => {
+        server.close();
+    });
+
+    it('should resolve true when expected answer is received', async () => {
+        const condition = new ConditionUDPAnswer({ ip: '127.0.0.1', port: 34568, message: 'Hello', answer: 'Ack' });
+        const result = await condition.evaluate({ abortSignal: new AbortController().signal });
+        expect(result).toBe(true);
+    });
+
+    it('should return false if aborted before evaluation', async () => {
+        const condition = new ConditionUDPAnswer({ ip: '127.0.0.1', port: 34568, message: 'Hello', answer: 'Ack' });
+        const controller = new AbortController();
+        controller.abort();
+        const result = await condition.evaluate({ abortSignal: controller.signal });
+        expect(result).toBe(false);
+    });
+
+    it('should throw an error for invalid ip', () => {
+        expect(() => new ConditionUDPAnswer({ ip: 'invalid', port: 1, message: 'a', answer: 'b' })).toThrow('Ip address must be a valid IPv4 address');
+    });
+});

--- a/src/app/src/domain/entities/conditions/types/udpAnswer/index.ts
+++ b/src/app/src/domain/entities/conditions/types/udpAnswer/index.ts
@@ -1,0 +1,91 @@
+import { Condition } from "../..";
+import { ConditionType } from "@common/types/condition.type";
+import dgram from 'dgram';
+
+interface ConditionUDPAnswerParams extends Partial<ConditionType> {
+    ip: string;
+    port: number;
+    message: string;
+    answer: string;
+    timeoutValue?: number;
+}
+
+export class ConditionUDPAnswer extends Condition {
+    static type = "udpAnswer";
+    ip: string;
+    port: number;
+    message: string;
+    answer: string;
+
+    constructor(options: ConditionUDPAnswerParams) {
+        super({
+            ...options,
+            type: ConditionUDPAnswer.type,
+            name: options.name || "UDP Answer Condition",
+            description: options.description || "Condition that waits for a UDP answer",
+            timeoutValue: options.timeoutValue
+        } as ConditionType);
+
+        const ipMask = /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+        if (!options.ip || !ipMask.test(options.ip))
+            throw new Error("Ip address must be a valid IPv4 address");
+        if (typeof options.port !== 'number' || options.port < 0 || options.port > 65535)
+            throw new Error("Port must be a number between 0 and 65535");
+        if (!options.message || typeof options.message !== 'string')
+            throw new Error("Message must be a string");
+        if (!options.answer || typeof options.answer !== 'string')
+            throw new Error("Answer must be a string");
+
+        this.ip = options.ip;
+        this.port = options.port;
+        this.message = options.message;
+        this.answer = options.answer;
+    }
+
+    protected async doEvaluation({ abortSignal }: { abortSignal: AbortSignal }): Promise<boolean> {
+        return new Promise((resolve, reject) => {
+            const socket = dgram.createSocket('udp4');
+            let finished = false;
+            const onAbort = () => {
+                if (!finished) {
+                    finished = true;
+                    socket.close();
+                    reject(new Error("Condition evaluation aborted"));
+                }
+            };
+
+            if (abortSignal.aborted) return onAbort();
+
+            abortSignal.addEventListener("abort", onAbort, { once: true });
+
+            socket.on('message', (msg) => {
+                const resp = msg.toString();
+                if (resp === this.answer) {
+                    finished = true;
+                    abortSignal.removeEventListener("abort", onAbort);
+                    socket.close();
+                    resolve(true);
+                }
+            });
+
+            socket.on('error', (err) => {
+                if (!finished) {
+                    finished = true;
+                    abortSignal.removeEventListener("abort", onAbort);
+                    socket.close();
+                    reject(err);
+                }
+            });
+
+            const buffer = Buffer.from(this.message);
+            socket.send(buffer, this.port, this.ip, (err) => {
+                if (err) {
+                    onAbort();
+                    reject(err);
+                }
+            });
+        });
+    }
+}
+
+export default ConditionUDPAnswer;


### PR DESCRIPTION
## Summary
- add `ConditionDayTime` as a day/hour/minute checking condition
- update TCP answer condition to log received message
- adjust info file for new condition
- provide tests for new condition

## Testing
- `npm run test:unit` *(fails: sendUDP.Job.test.ts broadcast address & udp.trigger.test.ts timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6851f113c2808327a97b854ebbedf830