### PR TITLE
Enable task drag and drop in NodeView

### DIFF
--- a/src/ui/contexts/dndContextProvider/indext.tsx
+++ b/src/ui/contexts/dndContextProvider/indext.tsx
@@ -1,17 +1,127 @@
-import React, { useState } from "react";
+import React, { createContext, useState, ReactNode } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  type DragStartEvent,
+  type DragEndEvent,
+  type DragCancelEvent,
+  type DragOverEvent,
+  closestCorners,
+} from "@dnd-kit/core";
+import { arrayMove } from "@dnd-kit/sortable";
+import TaskCard from "@views/NodeView/nodeTypes/RoutineNode/components/TaskCard";
+import styles from "@views/NodeView/style.module.css";
 
+export interface Task {
+  id: string;
+  content: string;
+  color?: string;
+}
 
-export const DndContextProvider = ({ children }) => {
+interface DndState {
+  tasks: Record<string, Task[]>;
+  setTasks: React.Dispatch<React.SetStateAction<Record<string, Task[]>>>;
+  activeTask: Task | null;
+  isDragging: boolean;
+}
 
-  const [activeTaskId, setActiveTaskId] = useState<string | null>(null);
-  const [activeTaskContainer, setActiveTaskContainer] = useState<string | null>(null);
+export const DndStateContext = createContext<DndState>({} as DndState);
 
+interface ProviderProps {
+  children: ReactNode;
+  initialTasks: Record<string, Task[]>;
+}
+
+export const DndContextProvider = ({ children, initialTasks }: ProviderProps) => {
+  const [tasks, setTasks] = useState<Record<string, Task[]>>(initialTasks);
+  const [activeTask, setActiveTask] = useState<Task | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const findContainer = (taskId: string): string | null => {
+    for (const [container, items] of Object.entries(tasks)) {
+      if (items.find((t) => t.id === taskId)) {
+        return container;
+      }
+    }
+    return null;
+  };
+
+  const handleDragStart = ({ active }: DragStartEvent) => {
+    const containerId = findContainer(active.id as string);
+    const task = containerId
+      ? tasks[containerId].find((t) => t.id === active.id)
+      : null;
+    setActiveTask(task || null);
+    setIsDragging(true);
+  };
+
+  const handleDragOver = ({ active, over }: DragOverEvent) => {
+    if (!over) return;
+    const activeContainer = findContainer(active.id as string);
+    const overContainer = findContainer(over.id as string) || over.id;
+    if (!activeContainer || !overContainer || activeContainer === overContainer) return;
+
+    setTasks((prev) => {
+      const activeIndex = prev[activeContainer].findIndex((t) => t.id === active.id);
+      const task = prev[activeContainer][activeIndex];
+      const newActive = prev[activeContainer].filter((t) => t.id !== active.id);
+      const newOver = [...prev[overContainer], task];
+      return { ...prev, [activeContainer]: newActive, [overContainer]: newOver };
+    });
+  };
+
+  const handleDragEnd = ({ active, over }: DragEndEvent) => {
+    const containerId = findContainer(active.id as string);
+    const overContainerId = over ? findContainer(over.id as string) || over.id : null;
+    if (!containerId) {
+      setActiveTask(null);
+      setIsDragging(false);
+      return;
+    }
+
+    if (over && containerId === overContainerId) {
+      setTasks((prev) => {
+        const containerTasks = prev[containerId];
+        const oldIndex = containerTasks.findIndex((t) => t.id === active.id);
+        const newIndex = containerTasks.findIndex((t) => t.id === over.id);
+        if (oldIndex !== newIndex) {
+          return {
+            ...prev,
+            [containerId]: arrayMove(containerTasks, oldIndex, newIndex),
+          };
+        }
+        return prev;
+      });
+    }
+    setActiveTask(null);
+    setIsDragging(false);
+  };
+
+  const handleDragCancel = (_: DragCancelEvent) => {
+    setActiveTask(null);
+    setIsDragging(false);
+  };
 
   return (
-    <div className="dndContextProvider">
-      {children}
-    </div>
+    <DndStateContext.Provider value={{ tasks, setTasks, activeTask, isDragging }}>
+      <DndContext
+        onDragStart={handleDragStart}
+        onDragOver={handleDragOver}
+        onDragEnd={handleDragEnd}
+        onDragCancel={handleDragCancel}
+        collisionDetection={closestCorners}
+      >
+        {children}
+        <DragOverlay modifiers={[]}>
+          {activeTask ? (
+            <div className={styles.dragOverlayCard}>
+              <TaskCard id={activeTask.id} containerId="" content={activeTask.content} color={activeTask.color} />
+            </div>
+          ) : null}
+        </DragOverlay>
+      </DndContext>
+    </DndStateContext.Provider>
   );
-}
+};
 
 export default DndContextProvider;

--- a/src/ui/views/NodeView/index.tsx
+++ b/src/ui/views/NodeView/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useContext } from 'react';
 import style from './style.module.css';
 import {
   addEdge,
@@ -12,8 +12,8 @@ import {
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import RoutineNode from './nodeTypes/RoutineNode';
-import { DndContext, type Modifier } from '@dnd-kit/core';
-import { DndContextProvider } from '@contexts/dndContextProvider/indext';
+import { type Modifier } from '@dnd-kit/core';
+import { DndContextProvider, DndStateContext } from '@contexts/dndContextProvider/indext';
 
 const nodeTypes = {
   routineNode: RoutineNode,
@@ -75,9 +75,9 @@ const NodeViewInner = () => {
     }, [zoom]
   );
 
+  const { tasks, isDragging } = useContext(DndStateContext);
   const [nodes, setNodes] = useState(initialNodes);
   const [edges, setEdges] = useState(initialEdges);
-  const [tasks, setTasks] = useState<Record<string, { id: string; content: string, color: string }[]>>(initialTasks);
 
 
 
@@ -104,8 +104,8 @@ const NodeViewInner = () => {
   return (
     <div className={style.nodeView}>
         <ReactFlow
-          panOnDrag={true}
-          nodesDraggable={true}
+          panOnDrag={!isDragging}
+          nodesDraggable={!isDragging}
           colorMode='dark'
           nodes={nodes.map((n) =>
             n.type === 'routineNode'
@@ -126,9 +126,11 @@ const NodeViewInner = () => {
 }
 
 const NodeView = () => (
-  <ReactFlowProvider>
-    <NodeViewInner />
-  </ReactFlowProvider>
+  <DndContextProvider initialTasks={initialTasks}>
+    <ReactFlowProvider>
+      <NodeViewInner />
+    </ReactFlowProvider>
+  </DndContextProvider>
 );
 
 export default NodeView;

--- a/src/ui/views/NodeView/nodeTypes/RoutineNode/components/TaskCard/index.tsx
+++ b/src/ui/views/NodeView/nodeTypes/RoutineNode/components/TaskCard/index.tsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import style from './style.module.css';
 
 interface TaskCardProps {
   id: string;
@@ -8,11 +11,29 @@ interface TaskCardProps {
 }
 
 const TaskCard: React.FC<TaskCardProps> = ({ id, containerId, content, color }) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id, data: { containerId } });
 
-
+  const styleCard: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    backgroundColor: color,
+  };
 
   return (
-    <div>
+    <div
+      ref={setNodeRef}
+      className={`${style.card} ${isDragging ? style.dragging : ''}`}
+      style={styleCard}
+      {...attributes}
+      {...listeners}
+    >
       {content}
     </div>
   );

--- a/src/ui/views/NodeView/nodeTypes/RoutineNode/components/TaskContainer/index.tsx
+++ b/src/ui/views/NodeView/nodeTypes/RoutineNode/components/TaskContainer/index.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from 'react';
-
+import React, { useEffect } from 'react';
+import { useDroppable } from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import TaskCard from '../TaskCard';
 import style from './style.module.css';
 
@@ -15,36 +16,34 @@ interface TaskContainerProps {
 }
 
 const TaskContainer: React.FC<TaskContainerProps> = ({ containerId, tasks }) => {
-    const [isDraggingOver, setIsDraggingOver] = useState(false);
+    const { setNodeRef, isOver } = useDroppable({ id: containerId });
 
     useEffect(() => {
-
-        console.log(isDraggingOver)
-        // If the container is hovered, set a fixed height
-
-        //setTaskContainerHeight('500px');
-    }, [isDraggingOver]);
-
+        // Could be used for styling when hovering
+    }, [isOver]);
 
     return (
             <div
+                ref={setNodeRef}
                 className={style.taskContainer}
                 style={{
                     backgroundColor: 'blue'
                 }}>
+                <SortableContext items={tasks.map(t => t.id)} strategy={verticalListSortingStrategy}>
                 {
                     tasks.length === 0
                         ? <div className={style.noTasks}>
                             <p>No tasks</p>
                         </div>
                         : tasks.map((task) =>
-                            <TaskCard   
-                                key={task.id} 
-                                id={task.id} 
-                                containerId={containerId} 
-                                content={task.content} 
+                            <TaskCard
+                                key={task.id}
+                                id={task.id}
+                                containerId={containerId}
+                                content={task.content}
                                 color={task.color} />)
                 }
+                </SortableContext>
 
             </div>
     );


### PR DESCRIPTION
## Summary
- add DndContextProvider to control drag state and overlay
- connect NodeView with DndContextProvider
- allow reordering and moving tasks across containers
- show dragged task in overlay
- disable ReactFlow pan and drag while moving tasks

## Testing
- `npm run test:unit` *(fails: SendUDPJob broadcast and UdpTrigger timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68587ac240508327abe8acca0ada4d98