### PR TITLE
Add instance identifiers when linking tasks and triggers to routines

### DIFF
--- a/currentProject.dc2
+++ b/currentProject.dc2
@@ -19,16 +19,16 @@
       "routineTimeout": 20000,
       "autoCheckConditionEveryMs": false,
       "triggersId": [
-        "ydtJn15O",
-        "0DWlU13O"
+        { "id": "VVnBlJ-F9v-trigger-1", "triggerId": "ydtJn15O" },
+        { "id": "VVnBlJ-F9v-trigger-2", "triggerId": "0DWlU13O" }
       ],
       "tasksId": [
-        "l9HYU0Sj",
-        "k26-mVw4",
-        "vLiHOH6t",
-        "eR0b9MUh",
-        "vLiHOH6t",
-        "mgypBUEP"
+        { "id": "VVnBlJ-F9v-task-1", "taskId": "l9HYU0Sj" },
+        { "id": "VVnBlJ-F9v-task-2", "taskId": "k26-mVw4" },
+        { "id": "VVnBlJ-F9v-task-3", "taskId": "vLiHOH6t" },
+        { "id": "VVnBlJ-F9v-task-4", "taskId": "eR0b9MUh" },
+        { "id": "VVnBlJ-F9v-task-5", "taskId": "vLiHOH6t" },
+        { "id": "VVnBlJ-F9v-task-6", "taskId": "mgypBUEP" }
       ]
     },
     {
@@ -42,12 +42,12 @@
       "routineTimeout": 10000,
       "autoCheckConditionEveryMs": false,
       "triggersId": [
-        "2n1SdvOd",
-        "Yn0vZSy9"
+        { "id": "W3lioPt28w-trigger-1", "triggerId": "2n1SdvOd" },
+        { "id": "W3lioPt28w-trigger-2", "triggerId": "Yn0vZSy9" }
       ],
       "tasksId": [
-        "WteROnKh",
-        "sQa_ne1A"
+        { "id": "W3lioPt28w-task-1", "taskId": "WteROnKh" },
+        { "id": "W3lioPt28w-task-2", "taskId": "sQa_ne1A" }
       ]
     }
   ],

--- a/src/app/src/domain/entities/project/project.test.ts
+++ b/src/app/src/domain/entities/project/project.test.ts
@@ -121,8 +121,8 @@ describe("Project Entity", () => {
         expect(savedProject.name).toBe("Recreated Project");
         expect(savedProject.routines.length).toBe(1);
         expect(savedProject.routines[0].name).toBe("Test Routine");
-        expect(savedProject.routines[0].tasks.length).toBe(1);
-        expect(savedProject.routines[0].tasks[0].name).toBe("Test Task");
+        expect(savedProject.routines[0].tasksId?.length).toBe(1);
+        expect(savedProject.routines[0].tasksId?.[0].taskId).toBe(project.tasks[0].id);
 
         project.close()
         expect(Project.getInstance()).toBeNull();

--- a/src/app/src/domain/useCases/routine/index.ts
+++ b/src/app/src/domain/useCases/routine/index.ts
@@ -62,28 +62,28 @@ export const createRoutine = async (routineData, projectData): Promise<Routine> 
   }
 
   // ---- Crear tasks a la rutina ----
-  for (const taskId of routineData.tasksId || []) {
-    if (taskId) {
-      const taskData = projectData.tasks.find(t => t.id === taskId);
+  for (const taskInstance of routineData.tasksId || []) {
+    if (taskInstance?.taskId) {
+      const taskData = projectData.tasks.find(t => t.id === taskInstance.taskId);
       if (!taskData) {
-        log.warn(`Task with ID ${taskId} not found for routine ${routine.id}`);
+        log.warn(`Task with ID ${taskInstance.taskId} not found for routine ${routine.id}`);
         continue;
       }
       const task = await createRoutineTask(taskData);
-      routine.addTask(task);
+      routine.addTask(task, taskInstance.id);
     }
   }
 
   // ---- Asociar triggers ----
-  for (const triggerId of routineData.triggersId || []) {
-    if (triggerId) {
-      const trigger = currentProject.triggers.find(t => t.id === triggerId);
+  for (const triggerInstance of routineData.triggersId || []) {
+    if (triggerInstance?.triggerId) {
+      const trigger = currentProject.triggers.find(t => t.id === triggerInstance.triggerId);
       if (trigger) {
-        routine.addTrigger(trigger);
+        routine.addTrigger(trigger, triggerInstance.id);
       }
-      else log.warn(`Trigger with ID ${triggerId} not found for routine ${routine.id}`);
+      else log.warn(`Trigger with ID ${triggerInstance.triggerId} not found for routine ${routine.id}`);
     } else {
-      log.warn(`Trigger with ID ${triggerId} not found for routine ${routine.id}`);
+      log.warn(`Trigger with ID ${triggerInstance?.triggerId} not found for routine ${routine.id}`);
     }
   }
 

--- a/src/common/types/routine.type.ts
+++ b/src/common/types/routine.type.ts
@@ -38,12 +38,12 @@ export interface RoutineType extends commonRoutineProps {
 export interface RoutineInterface extends commonRoutineProps {
     triggers: TriggerInterface[];
     tasks: TaskInterface[];
-    addTask: (task: TaskInterface) => void;
-    removeTask: (taskId: id) => void;
+    addTask: (task: TaskInterface, instanceId?: id) => void;
+    removeTask: (taskId: id, instanceId?: id) => void;
     getTasks: () => TaskInterface[];
     swapTaskOrder: (taskId: id, newIndex: number) => void;
-    addTrigger: (trigger: TriggerInterface) => void;
-    removeTrigger: (triggerId: id) => void;
+    addTrigger: (trigger: TriggerInterface, instanceId?: id) => void;
+    removeTrigger: (triggerId: id, instanceId?: id) => void;
     getTriggers: () => TriggerInterface[];
     run: (triggeredBy: TriggerInterface, ctx: Context) => void;
     abort: (cause: string) => void;

--- a/src/ui/helpers/dummy-project.ts
+++ b/src/ui/helpers/dummy-project.ts
@@ -14,8 +14,12 @@ export const dummyProjectData =
                 id: "routine-1",
                 name: "Routine 1",
                 description: "This is a dummy routine for testing purposes.",
-                tasksId: ["task-1"],
-                triggersId: ["apiTrigger-1"],
+                tasksId: [
+                    { id: "routine-1-task-1", taskId: "task-1" }
+                ],
+                triggersId: [
+                    { id: "routine-1-trigger-1", triggerId: "apiTrigger-1" }
+                ],
                 routineTimeout: 90000,
                 enabled: true,
                 autoCheckConditionEveryMs: false
@@ -24,24 +28,36 @@ export const dummyProjectData =
                 id: "routine-2",
                 name: "Routine 2",
                 description: "This routine will trigger when routine 1 is completed.",
-                tasksId: ["task-1"],
-                triggersId: ["routineEventTrigger-1"],
+                tasksId: [
+                    { id: "routine-2-task-1", taskId: "task-1" }
+                ],
+                triggersId: [
+                    { id: "routine-2-trigger-1", triggerId: "routineEventTrigger-1" }
+                ],
                 enabled: true,
             },
             {
                 id: "routine-3",
                 name: "Routine 3",
                 description: "This routine will trigger when routine 1 is aborted.",
-                tasksId: ["task-0"],
-                triggersId: ["routineEventTrigger-2"],
+                tasksId: [
+                    { id: "routine-3-task-1", taskId: "task-0" }
+                ],
+                triggersId: [
+                    { id: "routine-3-trigger-1", triggerId: "routineEventTrigger-2" }
+                ],
                 enabled: true,
             },
             {
                 id: "routine-4",
                 name: "Routine 4",
                 description: "This routine will trigger if routine 1 fails.",
-                tasksId: ["task-0"],
-                triggersId: ["routineEventTrigger-3"],
+                tasksId: [
+                    { id: "routine-4-task-1", taskId: "task-0" }
+                ],
+                triggersId: [
+                    { id: "routine-4-trigger-1", triggerId: "routineEventTrigger-3" }
+                ],
                 enabled: true,
             }
         ],

--- a/src/ui/views/Builder/components/Desktop/components/Panel/PanelBody/components/TriggerPanel/index.tsx
+++ b/src/ui/views/Builder/components/Desktop/components/Panel/PanelBody/components/TriggerPanel/index.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useEffect, useMemo, useRef, useState } from "react";
 import style from './style.module.css'
-import { useParams } from "react-router-dom";
+import { useParams, useSearchParams } from "react-router-dom";
 import useProject from "@hooks/useProject";
 import Text from "@components/Text";
 import { Input, Switch } from "antd";
@@ -10,7 +10,7 @@ import TypeTriggerField from "./components/TypeTriggerField";
 import TriggerParameters from "./components/TriggerParameters";
 import Footer from "./components/Footer";
 
-export const triggerContext = createContext({ trigger: undefined, setTrigger: (trigger: TriggerType) => { }, defaultTrigger: undefined, setInvalidParams: (params: string[]) => { }, invalidParams: [] as string[] });
+export const triggerContext = createContext({ trigger: undefined, setTrigger: (trigger: TriggerType) => { }, defaultTrigger: undefined, setInvalidParams: (params: string[]) => { }, invalidParams: [] as string[], triggerInstanceId: undefined });
 
 const defaultTrigger = {
     id: '',
@@ -23,9 +23,11 @@ const defaultTrigger = {
 
 const TriggerPanel = () => {
     const { triggerId } = useParams()
+    const [searchParams] = useSearchParams();
     const { project } = useProject({ fetchProject: false })
     const [trigger, setTrigger] = useState<TriggerType | undefined>(undefined);
     const [invalidParams, setInvalidParams] = useState<string[]>([]);
+    const triggerInstanceId = searchParams.get('instanceId') || undefined;
 
     useEffect(() => {
         if (project && triggerId) {
@@ -40,7 +42,7 @@ const TriggerPanel = () => {
     }, [project, triggerId])
 
     return (
-        <triggerContext.Provider value={{ trigger, setTrigger, defaultTrigger, setInvalidParams, invalidParams }}>
+        <triggerContext.Provider value={{ trigger, setTrigger, defaultTrigger, setInvalidParams, invalidParams, triggerInstanceId }}>
             <div className={style.triggerPanel}>
                 <div className={style.header}>
                     <Text color='white'>

--- a/src/ui/views/Builder/components/Desktop/components/RoutineContainer/components/Routine/components/Task/index.tsx
+++ b/src/ui/views/Builder/components/Desktop/components/RoutineContainer/components/Routine/components/Task/index.tsx
@@ -61,7 +61,8 @@ const Task = ({ taskData }) => {
 
     const handleOnMoreOptionsClick = (e) => {
         e.stopPropagation();
-        Navigate(`/builder/${routineData.id}/task/${taskData.id}`)
+        const queryParams = taskData.instanceId ? `?instanceId=${taskData.instanceId}` : "";
+        Navigate(`/builder/${routineData.id}/task/${taskData.id}${queryParams}`)
     }
 
 
@@ -99,7 +100,7 @@ const Task = ({ taskData }) => {
                 justifyContent: "center",
                 alignItems: "center",
             }}
-            id={taskData.id}>
+            id={taskData.instanceId || taskData.id}>
             <div className={style.taskContent}>
                 <div className={style.taskHeader}>
                     {getJobIcon(taskData.job.type)}

--- a/src/ui/views/Builder/components/Desktop/components/RoutineContainer/components/Routine/components/Trigger/index.tsx
+++ b/src/ui/views/Builder/components/Desktop/components/RoutineContainer/components/Routine/components/Trigger/index.tsx
@@ -17,7 +17,8 @@ const Trigger = ({ triggerData }) => {
 
     const handleOnMoreOptionsClick = (e) => {
         e.stopPropagation();
-        Navigate(`/builder/${routineData.id}/trigger/${triggerData.id}`)
+        const queryParams = triggerData.instanceId ? `?instanceId=${triggerData.instanceId}` : "";
+        Navigate(`/builder/${routineData.id}/trigger/${triggerData.id}${queryParams}`)
     }
 
     const handleOnAddNewTrigger = (e) => {
@@ -103,7 +104,7 @@ const Trigger = ({ triggerData }) => {
                     alignItems: "center",
                 }}
                 isDraggable={false}
-                id={triggerData.id}>
+                id={triggerData.instanceId || triggerData.id}>
                 <div className={style.triggerContent}>
                     <div className={style.triggerHeader}>
                         {getTriggerIcon(triggerData.type)}

--- a/src/ui/views/Builder/components/Desktop/components/RoutineContainer/components/Routine/components/TriggerContainer/index.tsx
+++ b/src/ui/views/Builder/components/Desktop/components/RoutineContainer/components/Routine/components/TriggerContainer/index.tsx
@@ -6,22 +6,28 @@ import useProject from "@hooks/useProject";
 import Text from "@components/Text";
 import Trigger from "../Trigger";
 import { nanoid } from "nanoid";
+import { TriggerInstance } from "@common/types/routine.type";
 
 const TriggersContainer = () => {
 
     const {routineData} = useContext(routineContext);
     const {project} = useProject({fetchProject: false})
-    const [triggers, setTriggers] = useState(routineData?.triggers || []);
+    const [triggers, setTriggers] = useState<any[]>(routineData?.triggers || []);
 
     useEffect(()=>{
         if (!project || !routineData || !project.triggers) return;
-        const routineTriggers = project.triggers.filter(trigger => routineData.triggersId?.includes(trigger.id)) || [];
-        setTriggers([...routineTriggers, {}])
+        const routineTriggers = (routineData.triggersId as TriggerInstance[] | undefined)?.map((triggerInstance) => {
+            const trigger = project.triggers.find(t => t.id === triggerInstance.triggerId);
+            if (!trigger) return null;
+            return { ...trigger, instanceId: triggerInstance.id };
+        }).filter(trigger => trigger !== null) || [];
+
+        setTriggers([...routineTriggers, { instanceId: nanoid(8), isPlaceholder: true }])
 
     },[project, routineData])
 
     const onSortEnd = (oldIndex: number, newIndex: number) => {
-        
+
     }   
 
     return (
@@ -40,7 +46,7 @@ const TriggersContainer = () => {
                     {
                         triggers?.map((trigger: any) => (
                             <Trigger
-                                key={trigger.id || nanoid(4)}
+                                key={trigger?.instanceId || trigger?.id || nanoid(4)}
                                 triggerData={trigger}/>
                         ))
                     }

--- a/src/ui/views/Control/components/Routine/components/PlayRoutineButton/index.tsx
+++ b/src/ui/views/Control/components/Routine/components/PlayRoutineButton/index.tsx
@@ -75,7 +75,11 @@ const PlayRoutineButton = ({ event, enabled }: { event: { event: string, data: a
 
     useEffect(() => {
         if (!project || !routine) return;
-        const routineTriggers = project.triggers.filter(trigger => routine.triggersId.includes(trigger.id));
+        const routineTriggers = project.triggers.filter(trigger => routine.triggersId?.some((triggerInstance: any) => {
+            if (typeof triggerInstance === 'string')
+                return triggerInstance === trigger.id;
+            return triggerInstance.triggerId === trigger.id;
+        }));
         const hasApiTrigger = routineTriggers.some(trigger => trigger.type === TriggerTypes.api);
         setApiTrigger(hasApiTrigger ? routineTriggers.find(trigger => trigger.type === TriggerTypes.api) : null);
         setShowButton(hasApiTrigger)


### PR DESCRIPTION
## Summary
- track task and trigger instances inside the routine entity and hydrate them via the routine use case
- update builder UI flows to work with instance identifiers when listing, reordering and removing routine items
- refresh bundled project data to store trigger/task associations as instance objects

## Testing
- npm run test:unit *(fails: existing suite expects network-dependent parameters for trigger/server tests)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0788d26c83279efe8ea37a7c04a2