### PR TITLE
Add PJLink 2.10 job and condition with UI support

### DIFF
--- a/src/app/src/domain/entities/conditions/types/index.ts
+++ b/src/app/src/domain/entities/conditions/types/index.ts
@@ -4,6 +4,7 @@ export const conditionTypes = {
     ping: "ping",
     tcpAnswer: "tcpAnswer",
     udpAnswer: "udpAnswer",
+    pjLinkPower: "pjLinkPower",
 } as const;
 
 export const getConditionTypes = async () : Promise<Record<string, any>> => {
@@ -12,6 +13,7 @@ export const getConditionTypes = async () : Promise<Record<string, any>> => {
         ping: await import("./ping/index.js"),
         tcpAnswer: await import("./tcpAnswer/index.js"),
         udpAnswer: await import("./udpAnswer/index.js"),
+        pjLinkPower: await import("./pjLinkPower/index.js"),
     }
     return conditions
 }

--- a/src/app/src/domain/entities/conditions/types/pjLinkPower/index.ts
+++ b/src/app/src/domain/entities/conditions/types/pjLinkPower/index.ts
@@ -1,0 +1,161 @@
+import { Condition } from "../..";
+import { ConditionType, requiredConditionParamType } from "@common/types/condition.type";
+import net from "net";
+import { conditionTypes } from "..";
+
+const PJLINK_PORT = 4352;
+const STATUS_OPTIONS = {
+    powerOn: {
+        label: "Chequear encendido",
+        expectedResponse: "%1POWR=1",
+    },
+    powerOff: {
+        label: "Chequear apagado",
+        expectedResponse: "%1POWR=0",
+    },
+} as const;
+
+type StatusKey = keyof typeof STATUS_OPTIONS;
+
+interface ConditionPJLinkPowerParams extends Partial<ConditionType> {
+    params: {
+        ip: string;
+        status: StatusKey;
+    };
+}
+
+export class ConditionPJLinkPower extends Condition {
+    static description = "Comprueba el estado de encendido de un dispositivo PJLink 2.10.";
+    static name = "Comprobar PJLink 2.10";
+    static type = conditionTypes.pjLinkPower;
+
+    constructor(options: ConditionPJLinkPowerParams) {
+        super({
+            ...options,
+            type: conditionTypes.pjLinkPower,
+            name: options.name || ConditionPJLinkPower.name,
+            description: options.description || ConditionPJLinkPower.description,
+        } as ConditionType);
+
+        this.validateParams();
+    }
+
+    requiredParams(): requiredConditionParamType[] {
+        return [
+            {
+                name: "ip",
+                required: true,
+                type: "string",
+                validationMask: "^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$",
+                description: "Dirección IP del dispositivo PJLink",
+            },
+            {
+                name: "status",
+                required: true,
+                type: "select",
+                validationMask: `^(${Object.keys(STATUS_OPTIONS).join("|")})$`,
+                description: "Estado que se desea comprobar",
+                options: Object.entries(STATUS_OPTIONS).map(([value, data]) => ({
+                    label: data.label,
+                    value,
+                })),
+            },
+        ];
+    }
+
+    protected async doEvaluation({ abortSignal }: { abortSignal: AbortSignal }): Promise<boolean> {
+        const { ip, status } = this.params as ConditionPJLinkPowerParams["params"];
+        const expected = STATUS_OPTIONS[status as StatusKey];
+
+        if (!expected) {
+            throw new Error(`Estado PJLink desconocido: ${status}`);
+        }
+
+        this.logger.info(`Comprobando estado PJLink (${expected.label}) en ${ip}`);
+
+        return new Promise((resolve, reject) => {
+            const client = new net.Socket();
+            let buffer = "";
+            let handshakeCompleted = false;
+            let finished = false;
+
+            const cleanup = () => {
+                if (finished) return;
+                finished = true;
+                client.removeAllListeners();
+                client.destroy();
+                abortSignal.removeEventListener("abort", onAbort);
+                clearTimeout(timeoutId);
+            };
+
+            const safeResolve = () => {
+                cleanup();
+                resolve(true);
+            };
+
+            const safeReject = (error: Error) => {
+                cleanup();
+                reject(error);
+            };
+
+            const onAbort = () => {
+                safeReject(new Error("Condition evaluation aborted"));
+            };
+
+            if (abortSignal.aborted) {
+                onAbort();
+                return;
+            }
+
+            abortSignal.addEventListener("abort", onAbort, { once: true });
+
+            const timeoutId = setTimeout(() => {
+                safeReject(new Error("Timeout esperando respuesta del dispositivo PJLink"));
+            }, 5000);
+
+            client.setEncoding("utf8");
+
+            client.on("error", (err) => {
+                safeReject(err);
+            });
+
+            client.on("data", (chunk: string | Buffer) => {
+                const piece = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+                buffer += piece;
+                const visible = piece.replace(/\r/g, "\\r").replace(/\n/g, "\\n");
+                this.logger.debug(`PJLink RX: "${visible}"`);
+
+                if (!handshakeCompleted) {
+                    if (buffer.includes("PJLINK 1")) {
+                        safeReject(new Error("El dispositivo requiere autenticación PJLink"));
+                        return;
+                    }
+
+                    if (buffer.includes("PJLINK 0")) {
+                        handshakeCompleted = true;
+                        buffer = "";
+                        client.write("%1POWR ?\r");
+                        this.logger.debug("Consulta de estado enviada: %1POWR ?");
+                    }
+
+                    return;
+                }
+
+                const normalized = buffer.replace(/\r/g, "").replace(/\n/g, "").trim();
+
+                if (normalized.includes(expected.expectedResponse)) {
+                    safeResolve();
+                    return;
+                }
+
+                if (/^%\d?ERR\d/.test(normalized)) {
+                    safeReject(new Error(`Respuesta PJLink de error: ${normalized}`));
+                }
+            });
+
+            client.connect(PJLINK_PORT, ip);
+        });
+    }
+}
+
+export default ConditionPJLinkPower;

--- a/src/app/src/domain/entities/job/types/index.ts
+++ b/src/app/src/domain/entities/job/types/index.ts
@@ -8,6 +8,7 @@ export const jobTypes = {
     sendSerialJob: "sendSerialJob",
     sendArtnetJob: "sendArtnetJob",
     sendMailJob: "sendMailJob",
+    sendPJLinkJob: "sendPJLinkJob",
 }
 
 export const getJobTypes = async () : Promise<Record<string, any>> => {
@@ -19,6 +20,7 @@ export const getJobTypes = async () : Promise<Record<string, any>> => {
         sendArtnetJob: await import("./sendArtnet/index.js"),
         wakeOnLanJob: await import("./wakeOnLan/index.js"),
         sendMailJob: await import("./sendMail/index.js"),
+        sendPJLinkJob: await import("./sendPJLink/index.js"),
     }
     return jobs
 }

--- a/src/app/src/domain/entities/job/types/sendPJLink/index.ts
+++ b/src/app/src/domain/entities/job/types/sendPJLink/index.ts
@@ -1,0 +1,190 @@
+import { JobType, requiredJobParamType } from "@common/types/job.type";
+import { Job } from "../..";
+import { jobTypes } from "..";
+import net from "net";
+import { Context } from "@src/domain/entities/context";
+
+const PJLINK_PORT = 4352;
+
+const COMMANDS = {
+    powerOn: {
+        label: "Encender proyector",
+        command: "%1POWR 1",
+        expectedResponse: "%1POWR=OK",
+    },
+    powerOff: {
+        label: "Apagar proyector",
+        command: "%1POWR 0",
+        expectedResponse: "%1POWR=OK",
+    },
+    checkPowerOn: {
+        label: "Chequear encendido",
+        command: "%1POWR ?",
+        expectedResponse: "%1POWR=1",
+    },
+    checkPowerOff: {
+        label: "Chequear apagado",
+        command: "%1POWR ?",
+        expectedResponse: "%1POWR=0",
+    },
+} as const;
+
+type CommandKey = keyof typeof COMMANDS;
+
+interface SendPJLinkJobParams extends JobType {
+    params: {
+        ipAddress: string;
+        command: CommandKey;
+    }
+}
+
+export class SendPJLinkJob extends Job {
+    static description = "Envía comandos PJLink 2.10 a un proyector.";
+    static name = "Enviar comando PJLink 2.10";
+    static type = jobTypes.sendPJLinkJob;
+
+    constructor(options: SendPJLinkJobParams) {
+        super({
+            ...options,
+            type: jobTypes.sendPJLinkJob,
+            timeout: 5000,
+            enableTimoutWatcher: true,
+        });
+
+        this.validateParams();
+    }
+
+    requiredParams(): requiredJobParamType[] {
+        const commandOptions = Object.entries(COMMANDS).map(([value, data]) => ({
+            label: `${data.label} (${data.command})`,
+            value,
+        }));
+
+        return [
+            {
+                name: "ipAddress",
+                type: "string",
+                validationMask: "^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$",
+                description: "Dirección IP del dispositivo PJLink",
+                required: true,
+            },
+            {
+                name: "command",
+                type: "select",
+                validationMask: `^(${Object.keys(COMMANDS).join("|")})$`,
+                description: "Comando PJLink a ejecutar",
+                required: true,
+                options: commandOptions,
+            },
+        ];
+    }
+
+    async job(ctx: Context): Promise<void> {
+        this.failed = false;
+        const { signal: abortSignal } = this.abortController || {};
+        const { ipAddress, command } = this.params as SendPJLinkJobParams["params"];
+
+        const selectedCommand = COMMANDS[command as CommandKey];
+        if (!selectedCommand)
+            throw new Error(`Comando PJLink desconocido: ${command}`);
+
+        ctx.log.info(`Iniciando comando PJLink ${selectedCommand.command} hacia ${ipAddress}`);
+        this.log.info(`Iniciando comando PJLink ${selectedCommand.command} hacia ${ipAddress}`);
+
+        await new Promise<void>((resolve, reject) => {
+            const client = new net.Socket();
+            let buffer = "";
+            let handshakeCompleted = false;
+            let finished = false;
+
+            const cleanup = () => {
+                if (finished) return;
+                finished = true;
+                client.removeAllListeners();
+                client.destroy();
+                if (abortSignal)
+                    abortSignal.removeEventListener("abort", onAbort);
+                clearTimeout(timeoutId);
+            };
+
+            const safeResolve = () => {
+                cleanup();
+                resolve();
+            };
+
+            const safeReject = (error: Error) => {
+                cleanup();
+                reject(error);
+            };
+
+            const onAbort = () => {
+                safeReject(new Error(`Job "${this.name}" was aborted`));
+            };
+
+            if (abortSignal) {
+                if (abortSignal.aborted) {
+                    onAbort();
+                    return;
+                }
+                abortSignal.addEventListener("abort", onAbort, { once: true });
+            }
+
+            const timeoutId = setTimeout(() => {
+                safeReject(new Error("Tiempo de espera agotado al comunicarse con el dispositivo PJLink"));
+            }, 5000);
+
+            client.setEncoding("utf8");
+
+            client.on("error", (err) => {
+                this.failed = true;
+                safeReject(err);
+            });
+
+            client.on("data", (chunk: string | Buffer) => {
+                const piece = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+                buffer += piece;
+                const visible = piece.replace(/\r/g, "\\r").replace(/\n/g, "\\n");
+                this.log.debug(`PJLink RX: "${visible}"`);
+
+                if (!handshakeCompleted) {
+                    if (buffer.includes("PJLINK 1")) {
+                        safeReject(new Error("El dispositivo requiere autenticación PJLink"));
+                        return;
+                    }
+
+                    if (buffer.includes("PJLINK 0")) {
+                        handshakeCompleted = true;
+                        buffer = "";
+                        const payload = `${selectedCommand.command}\r`;
+                        client.write(payload);
+                        this.log.info(`Comando enviado: ${selectedCommand.command}`);
+
+                        if (!selectedCommand.expectedResponse) {
+                            safeResolve();
+                        }
+                    }
+
+                    return;
+                }
+
+                const normalized = buffer.replace(/\r/g, "").replace(/\n/g, "").trim();
+
+                if (normalized.includes(selectedCommand.expectedResponse)) {
+                    safeResolve();
+                    return;
+                }
+
+                if (/^%\d?ERR\d/.test(normalized)) {
+                    safeReject(new Error(`Respuesta PJLink de error: ${normalized}`));
+                }
+            });
+
+            client.connect(PJLINK_PORT, ipAddress);
+        });
+
+        this.log.info(`Comando PJLink completado correctamente en ${ipAddress}`);
+        ctx.log.info(`Comando PJLink completado correctamente en ${ipAddress}`);
+    }
+}
+
+export default SendPJLinkJob;

--- a/src/common/types/condition.type.ts
+++ b/src/common/types/condition.type.ts
@@ -11,10 +11,11 @@ export type ConditionType = {
 
 export type requiredConditionParamType = {
     name: string;
-    type: "string" | "number" | "boolean" | "object";
+    type: "string" | "number" | "boolean" | "object" | "select";
     validationMask?: string;
     description: string;
     required: boolean;
+    options?: { label: string; value: string }[];
 }
 
 export interface ConditionInterface extends ConditionType {

--- a/src/common/types/job.type.ts
+++ b/src/common/types/job.type.ts
@@ -13,10 +13,11 @@ export type JobType = {
 
 export type requiredJobParamType = {
     name: string;
-    type: "string" | "number" | "boolean" | "object" | "array";
+    type: "string" | "number" | "boolean" | "object" | "array" | "select";
     validationMask?: string; // Regex pattern as string
     description: string;
     required: boolean;
+    options?: { label: string; value: string }[];
 }
 
 export interface JobInterface extends JobType {

--- a/src/ui/views/Builder/components/Desktop/components/RoutineContainer/components/Routine/components/Task/index.tsx
+++ b/src/ui/views/Builder/components/Desktop/components/RoutineContainer/components/Routine/components/Task/index.tsx
@@ -49,6 +49,8 @@ const Task = ({ taskData }) => {
                 return <MdWatchLater />;
             case "sendArtnetJob":
                 return getTextIcon("Artnet");
+            case "sendPJLinkJob":
+                return getTextIcon("PJ");
             default:
                 return null;
         }


### PR DESCRIPTION
## Summary
- add a PJLink 2.10 TCP job with predefined power commands and handshake handling
- introduce a PJLink power status condition that validates projector responses
- extend job/condition parameter typings and builder UI to support select options and show a PJ icon

## Testing
- `npm run test:unit` *(fails: existing Vitest suites are already broken in the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d0127d84348327aa5f584ce5b6933a