### PR TITLE
Implement i18n for context-aware logs

### DIFF
--- a/src/app/src/domain/entities/conditions/index.ts
+++ b/src/app/src/domain/entities/conditions/index.ts
@@ -3,6 +3,8 @@ import { ConditionInterface, ConditionType, requiredConditionParamType } from "@
 import { Log } from "@src/utils/log";
 import conditionEvents from "@common/events/condition.events";
 import { Context } from "../context";
+import dictionary from "@common/i18n";
+import crypto from "crypto";
 
 export class Condition extends EventEmitter implements ConditionInterface {
 
@@ -105,12 +107,12 @@ export class Condition extends EventEmitter implements ConditionInterface {
         try {
             await this.doEvaluation({ abortSignal });
             this.#dispatchEvent(conditionEvents.succeded);
-            ctx.log.info(`Evaluation succeeded`, null);
+            ctx.log.info(dictionary("app.domain.entities.condition.evaluationSucceeded", this.getDisplayName()));
             this.logger.info(`Evaluation succeeded`);
             return Promise.resolve(true);
         } catch (error) {
             this.logger.error(`Error during evaluation: ${error instanceof Error ? error.message : String(error)}`, error);
-            ctx.log.error(`Error during evaluation: ${error instanceof Error ? error.message : String(error)}`, null);
+            ctx.log.error(dictionary("app.domain.entities.condition.evaluationFailed", this.getDisplayName(), error instanceof Error ? error.message : String(error)));
             this.#dispatchEvent(conditionEvents.error, error);
             return Promise.reject(false);
         }
@@ -124,6 +126,10 @@ export class Condition extends EventEmitter implements ConditionInterface {
             type: this.type,
             params: this.params || {}
         };
+    }
+
+    private getDisplayName(): string {
+        return this.name || this.id;
     }
 
 }

--- a/src/app/src/domain/entities/job/types/sendPJLink/index.ts
+++ b/src/app/src/domain/entities/job/types/sendPJLink/index.ts
@@ -3,6 +3,7 @@ import { Job } from "../..";
 import { jobTypes } from "..";
 import net from "net";
 import { Context } from "@src/domain/entities/context";
+import dictionary from "@common/i18n";
 
 const PJLINK_PORT = 4352;
 
@@ -73,13 +74,14 @@ export class SendPJLinkJob extends Job {
         this.failed = false;
         const { signal: abortSignal } = this.abortController || {};
         const { ipAddress, command } = this.params as SendPJLinkJobParams["params"];
+        const displayName = this.name || this.id;
 
         const selectedCommand = COMMANDS[command as CommandKey];
         if (!selectedCommand)
             throw new Error(`Comando PJLink desconocido: ${command}`);
 
-        ctx.log.info(`Iniciando comando PJLink ${selectedCommand.command} hacia ${ipAddress}`);
-        this.log.info(`Iniciando comando PJLink ${selectedCommand.command} hacia ${ipAddress}`);
+        ctx.log.info(dictionary("app.domain.entities.job.sendPjLink.starting", selectedCommand.command, ipAddress));
+        this.log.info(dictionary("app.domain.entities.job.sendPjLink.starting", selectedCommand.command, ipAddress));
 
         await new Promise<void>((resolve, reject) => {
             const client = new net.Socket();
@@ -108,7 +110,7 @@ export class SendPJLinkJob extends Job {
             };
 
             const onAbort = () => {
-                safeReject(new Error(`Job "${this.name}" was aborted`));
+                safeReject(new Error(`Job "${displayName}" was aborted`));
             };
 
             if (abortSignal) {
@@ -166,8 +168,8 @@ export class SendPJLinkJob extends Job {
             client.connect(PJLINK_PORT, ipAddress);
         });
 
-        this.log.info(`Comando PJLink completado correctamente en ${ipAddress}`);
-        ctx.log.info(`Comando PJLink completado correctamente en ${ipAddress}`);
+        this.log.info(dictionary("app.domain.entities.job.sendPjLink.completed", ipAddress));
+        ctx.log.info(dictionary("app.domain.entities.job.sendPjLink.completed", ipAddress));
     }
 }
 

--- a/src/app/src/domain/entities/job/types/sendUDP/index.ts
+++ b/src/app/src/domain/entities/job/types/sendUDP/index.ts
@@ -5,6 +5,7 @@ import dgram from 'dgram';
 import { jobTypes } from "..";
 import ip from "ip";
 import { Context } from "@src/domain/entities/context";
+import dictionary from "@common/i18n";
 
 export interface SendUDPJobType extends JobType {
     params: {
@@ -60,8 +61,9 @@ export class SendUDPJob extends Job {
     async job(ctx: Context): Promise<void> {
         this.failed = false;
         const { signal: abortSignal } = this.abortController || {};
-        ctx.log.info(`Starting job "${this.name}" with ID ${this.id}`);
-        this.log.info(`Starting job "${this.name}" with ID ${this.id}`);
+        const displayName = this.name || this.id;
+        ctx.log.info(dictionary("app.domain.entities.job.sendUdp.starting", displayName));
+        this.log.info(dictionary("app.domain.entities.job.sendUdp.starting", displayName));
 
         let ipAddress, portNumber, message, subnetMask;
 
@@ -87,8 +89,8 @@ export class SendUDPJob extends Job {
         const client = dgram.createSocket('udp4');
 
         if (isBroadcast(ipAddress, subnetMask)) {
-            this.log.info(`Sending UDP packet to broadcast address ${ipAddress}:${portNumber}`);
-            ctx.log.info(`Sending UDP packet to broadcast address ${ipAddress}:${portNumber}`);
+            this.log.info(dictionary("app.domain.entities.job.sendUdp.sendingToBroadcast", ipAddress, portNumber));
+            ctx.log.info(dictionary("app.domain.entities.job.sendUdp.sendingToBroadcast", ipAddress, portNumber));
             client.bind(() => {
                 client.setBroadcast(true);
             });
@@ -124,23 +126,23 @@ export class SendUDPJob extends Job {
 
             client.send(messageBuffer, 0, messageBuffer.length, portNumber, ipAddress, (err) => {
                 if (err) {
-                    this.log.error(`Failed to send UDP packet: ${err.message}`);
-                    ctx.log.error(`Failed to send UDP packet: ${err.message}`);
+                    this.log.error(dictionary("app.domain.entities.job.sendUdp.failed", err.message));
+                    ctx.log.error(dictionary("app.domain.entities.job.sendUdp.failed", err.message));
                     return safeReject(err);
                 }
-                ctx.log.info(`UDP packet "${message}" sent to ${ipAddress}:${portNumber}`);
+                ctx.log.info(dictionary("app.domain.entities.job.sendUdp.sent", message, ipAddress, portNumber));
                 safeResolve();
             });
 
             if (abortSignal) {
                 abortSignal.addEventListener("abort", () => {
-                    safeReject(new Error(`Job "${this.name}" was aborted`));
+                    safeReject(new Error(`Job "${displayName}" was aborted`));
                 });
             }
         }).finally(() => {
             if (!this.abortedByUser) {
-                this.log.info(`Job "${this.name}" with ID ${this.id} has finished`);
-                ctx.log.info(`Job "${this.name}" with ID ${this.id} has finished`);
+                this.log.info(dictionary("app.domain.entities.job.sendUdp.finished", displayName));
+                ctx.log.info(dictionary("app.domain.entities.job.sendUdp.finished", displayName));
                 this.dispatchEvent(jobEvents.jobFinished, { jobId: this.id, failed: this.failed });
             }
         });

--- a/src/app/src/domain/entities/job/types/wait/index.ts
+++ b/src/app/src/domain/entities/job/types/wait/index.ts
@@ -3,6 +3,7 @@ import { Job } from "../..";
 import jobEvents from "@common/events/job.events";
 import { jobTypes } from "..";
 import { Context } from "@src/domain/entities/context";
+import dictionary from "@common/i18n";
 
 export class WaitJob extends Job {
     static description = "Waits for a specified amount of time before completing.";
@@ -38,8 +39,9 @@ export class WaitJob extends Job {
                return reject(new Error("AbortSignal is required for job execution"));
 
             const { time } = this.params;
+            const displayName = this.name || this.id;
             if (typeof time !== "number" || time < 0 || time > 2147483647) {
-                ctx.log.error(`Invalid 'time' parameter for job "${this.name}": ${time}`);
+                ctx.log.error(dictionary("app.domain.entities.job.wait.invalidTimeParameter", displayName, time));
                 this.failed = true;
                 this.dispatchEvent(jobEvents.jobError, { jobId: this.id, error: "Invalid time parameter" });
                 return reject(new Error("Invalid time parameter. Must be between 0 and 2147483647."));
@@ -63,7 +65,7 @@ export class WaitJob extends Job {
 
             abortListener = () => {
                 cleanup();
-                ctx.log.warn(`Job "${this.name}" was aborted`);
+                ctx.log.warn(dictionary("app.domain.entities.job.wait.aborted", displayName));
                 this.dispatchEvent(jobEvents.jobAborted, { jobId: this.id });
                 reject(new Error("Job aborted"));
             };
@@ -72,7 +74,7 @@ export class WaitJob extends Job {
 
             this.timeoutTimer = setTimeout(() => {
                 cleanup();
-                ctx.log.info(`Job "${this.name}" completed successfully`);
+                ctx.log.info(dictionary("app.domain.entities.job.wait.completed", displayName));
                 this.dispatchEvent(jobEvents.jobFinished, { jobId: this.id });
                 resolve();
             }, time);

--- a/src/app/src/domain/entities/job/types/wakeOnLan/index.ts
+++ b/src/app/src/domain/entities/job/types/wakeOnLan/index.ts
@@ -4,6 +4,7 @@ import jobEvents from "@common/events/job.events";
 import dgram from 'dgram';
 import { jobTypes } from "..";
 import { Context } from "@src/domain/entities/context";
+import dictionary from "@common/i18n";
 
 export interface WakeOnLanJobType extends JobType {
     params: {
@@ -54,8 +55,9 @@ export class WakeOnLanJob extends Job {
     async job(ctx: Context): Promise<void> {
         this.failed = false;
         const { signal: abortSignal } = this.abortController || {};
-        ctx.log.info(`Starting job "${this.name}" with ID ${this.id}`);
-        this.log.info(`Starting job "${this.name}" with ID ${this.id}`);
+        const displayName = this.name || this.id;
+        ctx.log.info(dictionary("app.domain.entities.job.wakeOnLan.starting", displayName));
+        this.log.info(dictionary("app.domain.entities.job.wakeOnLan.starting", displayName));
 
         let macAddress, portNumber
 
@@ -113,23 +115,23 @@ export class WakeOnLanJob extends Job {
             const messageBuffer = buildMagicPacket(macAddress);
             client.send(messageBuffer, 0, messageBuffer.length, portNumber, "255.255.255.255", (err) => {
                 if (err) {
-                    this.log.error(`Failed to send UDP packet: ${err.message}`);
-                    ctx.log.error(`Failed to send UDP packet: ${err.message}`);
+                    this.log.error(dictionary("app.domain.entities.job.wakeOnLan.failed", err.message));
+                    ctx.log.error(dictionary("app.domain.entities.job.wakeOnLan.failed", err.message));
                     return safeReject(err);
                 }
-                ctx.log.info(`UDP packet to wake device with MAC "${macAddress}" sent to port ${portNumber}`);
+                ctx.log.info(dictionary("app.domain.entities.job.wakeOnLan.sent", macAddress, portNumber));
                 safeResolve();
             });
 
             if (abortSignal) {
                 abortSignal.addEventListener("abort", () => {
-                    safeReject(new Error(`Job "${this.name}" was aborted`));
+                    safeReject(new Error(`Job "${displayName}" was aborted`));
                 });
             }
         }).finally(() => {
             if (!this.abortedByUser) {
-                this.log.info(`Job "${this.name}" with ID ${this.id} has finished`);
-                ctx.log.info(`Job "${this.name}" with ID ${this.id} has finished`);
+                this.log.info(dictionary("app.domain.entities.job.wakeOnLan.finished", displayName));
+                ctx.log.info(dictionary("app.domain.entities.job.wakeOnLan.finished", displayName));
                 this.dispatchEvent(jobEvents.jobFinished, { jobId: this.id, failed: this.failed });
             }
         });

--- a/src/app/src/domain/entities/trigger/index.ts
+++ b/src/app/src/domain/entities/trigger/index.ts
@@ -3,6 +3,8 @@ import { requiredTriggerParamType, TriggerInterface, TriggerType } from "@common
 import { Log } from "@src/utils/log";
 import triggerEvents from "@common/events/trigger.events";
 import { Context } from "../context";
+import dictionary from "@common/i18n";
+import crypto from "crypto";
 
 export class Trigger extends EventEmitter implements TriggerInterface {
     id: TriggerInterface["id"];
@@ -91,26 +93,26 @@ export class Trigger extends EventEmitter implements TriggerInterface {
 
         const origin = {
             type: "trigger",
-            id: this.id, name:
-                this.name
+            id: this.id,
+            name: this.name
         }
         const ctx = Context.createRootContext(origin);
 
         this.triggered = true;
         this.dispatchEvent(triggerEvents.triggered, { ctx });
         this.logger.info(`${this.type.charAt(0).toUpperCase() + this.type.slice(1).toLowerCase()} trigger triggered [ctx: ${ctx.id}]`);
-        ctx.log.info("Trigger activated");
+        ctx.log.info(dictionary("app.domain.entities.trigger.activated", this.getDisplayName()));
         this.disarm();
-        ctx.log.info("Trigger disarmed");
+        ctx.log.info(dictionary("app.domain.entities.trigger.disarmed", this.getDisplayName()));
 
         if (!this.reArmOnTrigger)
             return
 
-        if (!this.allowAutoRearming) 
+        if (!this.allowAutoRearming)
             return;
-        
+
         this.arm();
-        ctx.log.info("Trigger rearmed automatically");
+        ctx.log.info(dictionary("app.domain.entities.trigger.rearmed", this.getDisplayName()));
 
     }
 
@@ -148,6 +150,10 @@ export class Trigger extends EventEmitter implements TriggerInterface {
             params: this.params,
             type: this.type
         };
+    }
+
+    private getDisplayName(): string {
+        return this.name || this.id;
     }
 
 }

--- a/src/common/i18n/index.ts
+++ b/src/common/i18n/index.ts
@@ -1,32 +1,153 @@
-
 const LANG = String(process.env.DEFAULT_LANGUAGE || "es");
 
-
-export const dictionary = (key: string, ...params: any[]): string => {    
-    let translation = translations[LANG][key] || key;
-    if (params) {
+export const dictionary = (key: string, ...params: Array<string | number>): string => {
+    const translationsForLang = translations[LANG] ?? translations.es;
+    let translation = translationsForLang[key] || key;
+    if (params.length > 0) {
         params.forEach((param, index) => {
-            translation = translation.replace(`{${index + 1}}`, param);
+            translation = translation.replace(`{${index + 1}}`, String(param));
         });
     }
     return translation;
-}
+};
 
 const translations: { [key: string]: { [key: string]: string } } = {
     es: {
         "app.domain.entities.job.executed": "Se ejecutó el trabajo '{1}'",
         "app.domain.entities.job.aborted": "La ejecución del trabajo fue abortada.",
-        "app.domain.entities.job.abortedByUser": "La ejecución del trabajo '{%1}' fue abortada por el usuario.",
-        "app.domain.entities.job.failed": "La ejecución del trabajo falló: {%1}",
-        "app.domain.entities.job.finished": "La ejecución del trabajo ha finalizado exitosamente en {%1} ms.",
+        "app.domain.entities.job.abortedByUser": "La ejecución del trabajo '{1}' fue abortada por el usuario.",
+        "app.domain.entities.job.failed": "La ejecución del trabajo falló: {1}",
+        "app.domain.entities.job.finished": "La ejecución del trabajo ha finalizado exitosamente en {1} ms.",
+
+        "app.domain.entities.job.wait.invalidTimeParameter": "Parámetro 'time' inválido para el trabajo '{1}': {2}",
+        "app.domain.entities.job.wait.aborted": "Se abortó el trabajo '{1}'",
+        "app.domain.entities.job.wait.completed": "El trabajo '{1}' se completó correctamente",
+
+        "app.domain.entities.job.sendUdp.starting": "Iniciando el trabajo '{1}'",
+        "app.domain.entities.job.sendUdp.sendingToBroadcast": "Enviando paquete UDP a la dirección de broadcast {1}:{2}",
+        "app.domain.entities.job.sendUdp.failed": "Error al enviar el paquete UDP: {1}",
+        "app.domain.entities.job.sendUdp.sent": "Paquete UDP '{1}' enviado a {2}:{3}",
+        "app.domain.entities.job.sendUdp.finished": "El trabajo '{1}' ha finalizado",
+
+        "app.domain.entities.job.wakeOnLan.starting": "Iniciando el trabajo '{1}'",
+        "app.domain.entities.job.wakeOnLan.failed": "Error al enviar el paquete UDP: {1}",
+        "app.domain.entities.job.wakeOnLan.sent": "Paquete UDP para despertar el dispositivo con MAC '{1}' enviado al puerto {2}",
+        "app.domain.entities.job.wakeOnLan.finished": "El trabajo '{1}' ha finalizado",
+
+        "app.domain.entities.job.sendPjLink.starting": "Iniciando comando PJLink {1} hacia {2}",
+        "app.domain.entities.job.sendPjLink.completed": "Comando PJLink completado correctamente en {1}",
+
+        "app.domain.entities.trigger.activated": "El disparador '{1}' se activó",
+        "app.domain.entities.trigger.disarmed": "El disparador '{1}' se desarmó",
+        "app.domain.entities.trigger.rearmed": "El disparador '{1}' se rearma automáticamente",
+
+        "app.domain.entities.condition.evaluationSucceeded": "La evaluación de la condición '{1}' fue exitosa",
+        "app.domain.entities.condition.evaluationFailed": "Error durante la evaluación de la condición '{1}': {2}",
+
+        "app.domain.entities.routine.autoCheckingConditions": "Autoverificando condiciones para {1} tareas",
+        "app.domain.entities.routine.checkingConditionForTask": "Verificando condición para la tarea '{1}'",
+        "app.domain.entities.routine.started": "La rutina '{1}' inició",
+        "app.domain.entities.routine.runningTasksInSync": "Ejecutando tareas en secuencia...",
+        "app.domain.entities.routine.runningTask": "Ejecutando la tarea '{1}'...",
+        "app.domain.entities.routine.taskCompleted": "La tarea '{1}' finalizó",
+        "app.domain.entities.routine.taskAborted": "La tarea '{1}' fue abortada: {2}",
+        "app.domain.entities.routine.taskFailed": "La tarea '{1}' falló: {2}",
+        "app.domain.entities.routine.runningTasksInParallelBreak": "Ejecutando tareas en paralelo sin 'continuar en error'...",
+        "app.domain.entities.routine.tasksCompletedWithResult": "Tareas completadas: {1}",
+        "app.domain.entities.routine.tasksAborted": "Tareas abortadas: {1}",
+        "app.domain.entities.routine.runningTasksInParallelContinue": "Ejecutando tareas en paralelo con 'continuar en error'...",
+        "app.domain.entities.routine.tasksCompletedList": "Tareas completadas: {1}",
+        "app.domain.entities.routine.taskFailedReason": "La tarea falló: {1}",
+        "app.domain.entities.routine.taskFulfilledValue": "La tarea completó: {1}",
+        "app.domain.entities.routine.completed": "La rutina finalizó correctamente en {1} ms",
+        "app.domain.entities.routine.aborted": "La rutina fue abortada por el usuario: {1}",
+        "app.domain.entities.routine.timedOut": "La rutina alcanzó el tiempo máximo: {1}",
+        "app.domain.entities.routine.failed": "La rutina finalizó con errores: {1}",
+
+        "app.domain.entities.task.starting": "Iniciando la tarea '{1}'",
+        "app.domain.entities.task.aborted": "La tarea '{1}' fue abortada",
+        "app.domain.entities.task.timedOut": "La tarea '{1}' excedió el tiempo máximo",
+        "app.domain.entities.task.failed": "La tarea '{1}' falló: {2}",
+        "app.domain.entities.task.completed": "La tarea '{1}' finalizó correctamente en {2} ms",
+        "app.domain.entities.task.conditionMet": "La condición de la tarea '{1}' se cumplió, finalizando ejecución",
+        "app.domain.entities.task.checkingConditionBefore": "Verificando condición antes de ejecutar la tarea '{1}'",
+        "app.domain.entities.task.executingJobAttempt": "Ejecutando el trabajo de la tarea '{1}', intento {2} de {3}",
+        "app.domain.entities.task.noCondition": "La tarea '{1}' no tiene condición, finalizando ejecución",
+        "app.domain.entities.task.conditionNotMetAfter": "La condición de la tarea '{1}' no se cumplió tras ejecutar el trabajo, se reintenta",
+        "app.domain.entities.task.abortedNotContinuing": "La tarea '{1}' fue abortada, no se continúa",
+        "app.domain.entities.task.error": "Error en la tarea '{1}': {2}",
+        "app.domain.entities.task.failedNoContinue": "La tarea '{1}' falló y no continuará porque 'continuar en error' está deshabilitado",
+        "app.domain.entities.task.maxRetries": "Se alcanzó el máximo de reintentos para la tarea '{1}'",
+        "app.domain.entities.task.retrying": "Reintentando la tarea '{1}' en {2} ms",
     },
     en: {
         "app.domain.entities.job.executed": "Job '{1}' executed",
         "app.domain.entities.job.aborted": "Job execution was aborted.",
-        "app.domain.entities.job.abortedByUser": "Job '{%1}' execution was aborted by the user.",
-        "app.domain.entities.job.failed": "Job execution failed: {%1}",
-        "app.domain.entities.job.finished": "Job execution finished successfully in {%1} ms."
+        "app.domain.entities.job.abortedByUser": "Job '{1}' execution was aborted by the user.",
+        "app.domain.entities.job.failed": "Job execution failed: {1}",
+        "app.domain.entities.job.finished": "Job execution finished successfully in {1} ms.",
+
+        "app.domain.entities.job.wait.invalidTimeParameter": "Invalid 'time' parameter for job '{1}': {2}",
+        "app.domain.entities.job.wait.aborted": "Job '{1}' was aborted",
+        "app.domain.entities.job.wait.completed": "Job '{1}' completed successfully",
+
+        "app.domain.entities.job.sendUdp.starting": "Starting job '{1}'",
+        "app.domain.entities.job.sendUdp.sendingToBroadcast": "Sending UDP packet to broadcast address {1}:{2}",
+        "app.domain.entities.job.sendUdp.failed": "Failed to send UDP packet: {1}",
+        "app.domain.entities.job.sendUdp.sent": "UDP packet '{1}' sent to {2}:{3}",
+        "app.domain.entities.job.sendUdp.finished": "Job '{1}' has finished",
+
+        "app.domain.entities.job.wakeOnLan.starting": "Starting job '{1}'",
+        "app.domain.entities.job.wakeOnLan.failed": "Failed to send UDP packet: {1}",
+        "app.domain.entities.job.wakeOnLan.sent": "UDP packet to wake device with MAC '{1}' sent to port {2}",
+        "app.domain.entities.job.wakeOnLan.finished": "Job '{1}' has finished",
+
+        "app.domain.entities.job.sendPjLink.starting": "Starting PJLink command {1} to {2}",
+        "app.domain.entities.job.sendPjLink.completed": "PJLink command completed successfully in {1}",
+
+        "app.domain.entities.trigger.activated": "Trigger '{1}' activated",
+        "app.domain.entities.trigger.disarmed": "Trigger '{1}' disarmed",
+        "app.domain.entities.trigger.rearmed": "Trigger '{1}' rearmed automatically",
+
+        "app.domain.entities.condition.evaluationSucceeded": "Condition '{1}' evaluation succeeded",
+        "app.domain.entities.condition.evaluationFailed": "Error during condition '{1}' evaluation: {2}",
+
+        "app.domain.entities.routine.autoCheckingConditions": "Autochecking conditions for {1} tasks",
+        "app.domain.entities.routine.checkingConditionForTask": "Checking condition for task '{1}'",
+        "app.domain.entities.routine.started": "Routine '{1}' started",
+        "app.domain.entities.routine.runningTasksInSync": "Running tasks in sync...",
+        "app.domain.entities.routine.runningTask": "Running task '{1}'...",
+        "app.domain.entities.routine.taskCompleted": "Task '{1}' completed",
+        "app.domain.entities.routine.taskAborted": "Task '{1}' aborted: {2}",
+        "app.domain.entities.routine.taskFailed": "Task '{1}' failed: {2}",
+        "app.domain.entities.routine.runningTasksInParallelBreak": "Running tasks in parallel without continueOnError...",
+        "app.domain.entities.routine.tasksCompletedWithResult": "Tasks completed: {1}",
+        "app.domain.entities.routine.tasksAborted": "Tasks aborted: {1}",
+        "app.domain.entities.routine.runningTasksInParallelContinue": "Running tasks in parallel with continueOnError...",
+        "app.domain.entities.routine.tasksCompletedList": "Tasks completed: {1}",
+        "app.domain.entities.routine.taskFailedReason": "Task failed: {1}",
+        "app.domain.entities.routine.taskFulfilledValue": "Task completed: {1}",
+        "app.domain.entities.routine.completed": "Routine completed successfully in {1} ms",
+        "app.domain.entities.routine.aborted": "Routine aborted by user: {1}",
+        "app.domain.entities.routine.timedOut": "Routine timed out: {1}",
+        "app.domain.entities.routine.failed": "Routine ended with error: {1}",
+
+        "app.domain.entities.task.starting": "Starting task '{1}'",
+        "app.domain.entities.task.aborted": "Task '{1}' aborted",
+        "app.domain.entities.task.timedOut": "Task '{1}' timed out",
+        "app.domain.entities.task.failed": "Task '{1}' failed: {2}",
+        "app.domain.entities.task.completed": "Task '{1}' completed successfully in {2} ms",
+        "app.domain.entities.task.conditionMet": "Condition met for task '{1}', finishing execution",
+        "app.domain.entities.task.checkingConditionBefore": "Checking condition before executing task '{1}'",
+        "app.domain.entities.task.executingJobAttempt": "Executing job for task '{1}', attempt {2} of {3}",
+        "app.domain.entities.task.noCondition": "No condition set for task '{1}', finishing execution",
+        "app.domain.entities.task.conditionNotMetAfter": "Condition not met for task '{1}' after job execution, will retry",
+        "app.domain.entities.task.abortedNotContinuing": "Task '{1}' aborted, not continuing",
+        "app.domain.entities.task.error": "Error in task '{1}': {2}",
+        "app.domain.entities.task.failedNoContinue": "Task '{1}' failed and will not continue because continueOnError is false",
+        "app.domain.entities.task.maxRetries": "Max retries reached for task '{1}'",
+        "app.domain.entities.task.retrying": "Retrying task '{1}' in {2} ms",
     }
-}
+};
 
 export default dictionary;


### PR DESCRIPTION
## Summary
- internationalize context-driven log messages for tasks, routines, triggers, conditions, and jobs
- expand the shared dictionary with translations for new domain events and prefer entity names over IDs
- update job implementations to reuse the new translations and surface human-friendly identifiers in logs

## Testing
- npm test *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68d953b268dc83279857f02f72affcb1