### PR TITLE
Localize rejection messages for context-aware entities

### DIFF
--- a/src/app/src/domain/entities/conditions/index.ts
+++ b/src/app/src/domain/entities/conditions/index.ts
@@ -3,6 +3,8 @@ import { ConditionInterface, ConditionType, requiredConditionParamType } from "@
 import { Log } from "@src/utils/log";
 import conditionEvents from "@common/events/condition.events";
 import { Context } from "../context";
+import dictionary from "@common/i18n";
+import crypto from "crypto";
 
 export class Condition extends EventEmitter implements ConditionInterface {
 
@@ -105,12 +107,12 @@ export class Condition extends EventEmitter implements ConditionInterface {
         try {
             await this.doEvaluation({ abortSignal });
             this.#dispatchEvent(conditionEvents.succeded);
-            ctx.log.info(`Evaluation succeeded`, null);
+            ctx.log.info(dictionary("app.domain.entities.condition.evaluationSucceeded", this.getDisplayName()));
             this.logger.info(`Evaluation succeeded`);
             return Promise.resolve(true);
         } catch (error) {
             this.logger.error(`Error during evaluation: ${error instanceof Error ? error.message : String(error)}`, error);
-            ctx.log.error(`Error during evaluation: ${error instanceof Error ? error.message : String(error)}`, null);
+            ctx.log.error(dictionary("app.domain.entities.condition.evaluationFailed", this.getDisplayName(), error instanceof Error ? error.message : String(error)));
             this.#dispatchEvent(conditionEvents.error, error);
             return Promise.reject(false);
         }
@@ -124,6 +126,10 @@ export class Condition extends EventEmitter implements ConditionInterface {
             type: this.type,
             params: this.params || {}
         };
+    }
+
+    private getDisplayName(): string {
+        return this.name || this.id;
     }
 
 }

--- a/src/app/src/domain/entities/conditions/types/dayTime/index.ts
+++ b/src/app/src/domain/entities/conditions/types/dayTime/index.ts
@@ -1,7 +1,7 @@
-import { S } from "vitest/dist/chunks/config.Cy0C388Z.js";
 import { conditionTypes } from "..";
 import { Condition } from "../..";
 import { ConditionType, requiredConditionParamType } from "@common/types/condition.type";
+import dictionary from "@common/i18n";
 
 interface ConditionDayTimeParams extends Partial<ConditionType> {
     day?: number;
@@ -63,8 +63,9 @@ export class ConditionDayTime extends Condition {
 
     protected async doEvaluation({ abortSignal }: { abortSignal: AbortSignal }): Promise<boolean> {
         return new Promise((resolve, reject) => {
+            const displayName = this.name || this.id;
             if (abortSignal.aborted) {
-                return reject(new Error("Condition evaluation aborted"));
+                return reject(new Error(dictionary("app.domain.entities.condition.evaluationAborted", displayName)));
             }
             const now = new Date();
             const dayMatch = this.day === undefined || now.getDay() === this.day;
@@ -74,7 +75,7 @@ export class ConditionDayTime extends Condition {
             if (dayMatch && hourMatch && minuteMatch) {
                 resolve(true);
             } else {
-                reject(new Error("Condition not met"));
+                reject(new Error(dictionary("app.domain.entities.condition.notMet", displayName)));
             }
         });
     }

--- a/src/app/src/domain/entities/conditions/types/ping/index.ts
+++ b/src/app/src/domain/entities/conditions/types/ping/index.ts
@@ -2,6 +2,7 @@ import { Condition } from "../..";
 import { ConditionType, requiredConditionParamType } from "@common/types/condition.type";
 import * as ping from "ping";
 import { conditionTypes } from "..";
+import dictionary from "@common/i18n";
 
 interface ConditionPingParams extends Partial<ConditionType> {
     ipAddress: string;
@@ -52,8 +53,9 @@ export class ConditionPing extends Condition {
     }
 
     protected async doEvaluation({ abortSignal }: { abortSignal: AbortSignal }): Promise<boolean> {
+        const displayName = this.name || this.id;
         if (abortSignal.aborted) {
-            return Promise.reject(new Error("Condition evaluation aborted"));
+            return Promise.reject(new Error(dictionary("app.domain.entities.condition.evaluationAborted", displayName)));
         }
 
         return new Promise((resolve, reject) => {
@@ -62,7 +64,7 @@ export class ConditionPing extends Condition {
 
             abortSignal.addEventListener("abort", () => {
                 aborted = true;
-                reject(new Error("Condition evaluation aborted"));
+                reject(new Error(dictionary("app.domain.entities.condition.evaluationAborted", displayName)));
             });
 
             pingPromise.then((res: any) => {
@@ -71,7 +73,7 @@ export class ConditionPing extends Condition {
                 if (result) {
                     resolve(true);
                 } else {
-                    reject(new Error("Ping failed: destination unreachable"));
+                    reject(new Error(dictionary("app.domain.entities.condition.pingFailed", displayName)));
                 }
             }).catch(reject);
         });

--- a/src/app/src/domain/entities/conditions/types/pjLinkPower/index.ts
+++ b/src/app/src/domain/entities/conditions/types/pjLinkPower/index.ts
@@ -2,6 +2,7 @@ import { Condition } from "../..";
 import { ConditionType, requiredConditionParamType } from "@common/types/condition.type";
 import net from "net";
 import { conditionTypes } from "..";
+import dictionary from "@common/i18n";
 
 const PJLINK_PORT = 4352;
 const STATUS_OPTIONS = {
@@ -68,7 +69,7 @@ export class ConditionPJLinkPower extends Condition {
         const expected = STATUS_OPTIONS[status as StatusKey];
 
         if (!expected) {
-            throw new Error(`Estado PJLink desconocido: ${status}`);
+            throw new Error(dictionary("app.domain.entities.condition.pjlinkUnknownStatus", status));
         }
 
         this.logger.info(`Comprobando estado PJLink (${expected.label}) en ${ip}`);
@@ -78,6 +79,7 @@ export class ConditionPJLinkPower extends Condition {
             let buffer = "";
             let handshakeCompleted = false;
             let finished = false;
+            const displayName = this.name || this.id;
 
             const cleanup = () => {
                 if (finished) return;
@@ -99,7 +101,7 @@ export class ConditionPJLinkPower extends Condition {
             };
 
             const onAbort = () => {
-                safeReject(new Error("Condition evaluation aborted"));
+                safeReject(new Error(dictionary("app.domain.entities.condition.evaluationAborted", displayName)));
             };
 
             if (abortSignal.aborted) {
@@ -110,7 +112,7 @@ export class ConditionPJLinkPower extends Condition {
             abortSignal.addEventListener("abort", onAbort, { once: true });
 
             const timeoutId = setTimeout(() => {
-                safeReject(new Error("Timeout esperando respuesta del dispositivo PJLink"));
+                safeReject(new Error(dictionary("app.domain.entities.condition.pjlinkTimeout")));
             }, 5000);
 
             client.setEncoding("utf8");
@@ -127,7 +129,7 @@ export class ConditionPJLinkPower extends Condition {
 
                 if (!handshakeCompleted) {
                     if (buffer.includes("PJLINK 1")) {
-                        safeReject(new Error("El dispositivo requiere autenticación PJLink"));
+                        safeReject(new Error(dictionary("app.domain.entities.condition.pjlinkAuthRequired")));
                         return;
                     }
 
@@ -149,7 +151,7 @@ export class ConditionPJLinkPower extends Condition {
                 }
 
                 if (/^%\d?ERR\d/.test(normalized)) {
-                    safeReject(new Error(`Respuesta PJLink de error: ${normalized}`));
+                    safeReject(new Error(dictionary("app.domain.entities.condition.pjlinkErrorResponse", normalized)));
                 }
             });
 

--- a/src/app/src/domain/entities/conditions/types/tcpAnswer/index.ts
+++ b/src/app/src/domain/entities/conditions/types/tcpAnswer/index.ts
@@ -2,6 +2,7 @@ import { Condition } from "../..";
 import { ConditionType, requiredConditionParamType } from "@common/types/condition.type";
 import net from 'net';
 import { conditionTypes } from "..";
+import dictionary from "@common/i18n";
 
 interface ConditionTCPAnswerParams extends Partial<ConditionType> {
     ip: string;
@@ -76,10 +77,11 @@ export class ConditionTCPAnswer extends Condition {
             const client = new net.Socket();
             let buf = "";                             // acumulador
             const expected = this.answer;
+            const displayName = this.name || this.id;
 
             const onAbort = () => {
                 client.destroy();
-                reject(new Error("Condition evaluation aborted"));
+                reject(new Error(dictionary("app.domain.entities.condition.evaluationAborted", displayName)));
             };
 
             if (abortSignal.aborted) return onAbort();

--- a/src/app/src/domain/entities/conditions/types/udpAnswer/index.ts
+++ b/src/app/src/domain/entities/conditions/types/udpAnswer/index.ts
@@ -2,6 +2,7 @@ import { Condition } from "../..";
 import { ConditionType, requiredConditionParamType } from "@common/types/condition.type";
 import dgram from 'dgram';
 import { conditionTypes } from "..";
+import dictionary from "@common/i18n";
 
 interface ConditionUDPAnswerParams extends Partial<ConditionType> {
     ip: string;
@@ -84,14 +85,15 @@ export class ConditionUDPAnswer extends Condition {
         return new Promise((resolve, reject) => {
 
             const socket = dgram.createSocket('udp4');
-            
+
 
             let finished = false;
+            const displayName = this.name || this.id;
             const onAbort = () => {
                 if (!finished) {
                     finished = true;
                     socket.close();
-                    reject(new Error("Condition evaluation aborted"));
+                    reject(new Error(dictionary("app.domain.entities.condition.evaluationAborted", displayName)));
                 }
             };
 

--- a/src/app/src/domain/entities/job/types/wait/index.ts
+++ b/src/app/src/domain/entities/job/types/wait/index.ts
@@ -3,6 +3,7 @@ import { Job } from "../..";
 import jobEvents from "@common/events/job.events";
 import { jobTypes } from "..";
 import { Context } from "@src/domain/entities/context";
+import dictionary from "@common/i18n";
 
 export class WaitJob extends Job {
     static description = "Waits for a specified amount of time before completing.";
@@ -31,18 +32,20 @@ export class WaitJob extends Job {
 
     async job(ctx: Context, abortSignal: AbortSignal): Promise<void> {
         return new Promise<void>((resolve, reject) => {
+            const displayName = this.getDisplayName();
+
             if (ctx == null)
-                return reject(new Error("Context is required for job execution"));
+                return reject(new Error(dictionary("app.domain.entities.job.contextRequired", displayName)));
 
             if (abortSignal == null)
-               return reject(new Error("AbortSignal is required for job execution"));
+               return reject(new Error(dictionary("app.domain.entities.job.abortSignalRequired", displayName)));
 
             const { time } = this.params;
             if (typeof time !== "number" || time < 0 || time > 2147483647) {
-                ctx.log.error(`Invalid 'time' parameter for job "${this.name}": ${time}`);
+                ctx.log.error(dictionary("app.domain.entities.job.wait.invalidTimeParameter", displayName, time));
                 this.failed = true;
                 this.dispatchEvent(jobEvents.jobError, { jobId: this.id, error: "Invalid time parameter" });
-                return reject(new Error("Invalid time parameter. Must be between 0 and 2147483647."));
+                return reject(new Error(dictionary("app.domain.entities.job.wait.invalidTimeParameter", displayName, time)));
             }
 
             this.failed = false;
@@ -63,16 +66,16 @@ export class WaitJob extends Job {
 
             abortListener = () => {
                 cleanup();
-                ctx.log.warn(`Job "${this.name}" was aborted`);
+                ctx.log.warn(dictionary("app.domain.entities.job.wait.aborted", displayName));
                 this.dispatchEvent(jobEvents.jobAborted, { jobId: this.id });
-                reject(new Error("Job aborted"));
+                reject(new Error(dictionary("app.domain.entities.job.aborted", displayName)));
             };
 
             abortSignal.addEventListener("abort", abortListener);
 
             this.timeoutTimer = setTimeout(() => {
                 cleanup();
-                ctx.log.info(`Job "${this.name}" completed successfully`);
+                ctx.log.info(dictionary("app.domain.entities.job.wait.completed", displayName));
                 this.dispatchEvent(jobEvents.jobFinished, { jobId: this.id });
                 resolve();
             }, time);

--- a/src/app/src/domain/entities/routine/index.ts
+++ b/src/app/src/domain/entities/routine/index.ts
@@ -19,6 +19,7 @@ import { Trigger } from "../trigger";
 import { Context } from "../context";
 import { TimeoutController } from "@src/controllers/Timeout";
 import timeoutEvents from "@common/events/timeout.events";
+import dictionary from "@common/i18n";
 
 export const RoutineActions = ["enable", "disable", "run", "stop"] as const;
 export type RoutineActions = typeof RoutineActions[number];
@@ -328,6 +329,14 @@ export class Routine extends EventEmitter implements RoutineInterface {
         return [...this.triggers];
     }
 
+    private getDisplayName(): string {
+        return this.name || this.id;
+    }
+
+    private getTaskDisplayName(task: TaskInterface): string {
+        return task?.name || task?.id || "";
+    }
+
     #eventDispatcher(event: string, ...args: any[]): void {
         const newArgs = {
             routineId: this.id,
@@ -360,15 +369,15 @@ export class Routine extends EventEmitter implements RoutineInterface {
         const tasksWithConditions = this.tasks.filter(t => t.condition);
         if (tasksWithConditions.length === 0) return true;
 
-        const ctx = Context.createRootContext({ type: "routine", id: this.id });
+        const ctx = Context.createRootContext({ type: "routine", id: this.id, name: this.name });
 
-        ctx.log.info(`Autochecking conditions for ${tasksWithConditions.length} tasks`);
+        ctx.log.info(dictionary("app.domain.entities.routine.autoCheckingConditions", tasksWithConditions.length));
 
         const abortController = new AbortController();
         const { signal: abortSignal } = abortController;
         const results = await Promise.all(tasksWithConditions.map(task => {
 
-            ctx.log.info(`Checking condition for task ${task.name}`, [this.id]);
+            ctx.log.info(dictionary("app.domain.entities.routine.checkingConditionForTask", this.getTaskDisplayName(task)), [this.id]);
 
             return task.condition!.evaluate({ abortSignal, ctx });
         }));
@@ -376,17 +385,19 @@ export class Routine extends EventEmitter implements RoutineInterface {
     }
 
     async run(triggeredBy: TriggerInterface, ctx: Context): Promise<void> {
+        const displayName = this.getDisplayName();
+
         if (!this.enabled)
-            throw new Error(`Routine ${this.name} is not enabled`);
+            throw new Error(dictionary("app.domain.entities.routine.notEnabled", displayName));
 
         if (!triggeredBy?.id)
-            throw new Error(`Routine ${this.name} is not triggered by a valid trigger`);
+            throw new Error(dictionary("app.domain.entities.routine.invalidTrigger", displayName));
 
         if (this.isRunning)
-            throw new Error(`Routine ${this.name} is already running`);
+            throw new Error(dictionary("app.domain.entities.routine.alreadyRunning", displayName));
 
         if (!(ctx instanceof Context)) {
-            throw new Error(`Invalid context provided`);
+            throw new Error(dictionary("app.domain.entities.routine.invalidContext", displayName));
         }
 
         const routineStartTime = Date.now();
@@ -411,7 +422,7 @@ export class Routine extends EventEmitter implements RoutineInterface {
             name: this.name
         };
         const childCtx = ctx.createChildContext(ctxNode);
-        childCtx.log.info(`Routine ${this.name} started`);
+        childCtx.log.info(dictionary("app.domain.entities.routine.started", displayName));
 
         childCtx.onFinish((data) => {
             this.#eventDispatcher(routineEvents.routineFinished, data);
@@ -420,25 +431,25 @@ export class Routine extends EventEmitter implements RoutineInterface {
         return new Promise(async (resolve, reject) => {
 
             const runInSync = async (abortSignal: AbortSignal) => {
-                this.logger.info(childCtx.log.info("Running tasks in sync..."));
+                this.logger.info(childCtx.log.info(dictionary("app.domain.entities.routine.runningTasksInSync")));
 
                 for (const task of this.tasks) {
                     try {
-                        childCtx.log.info(`Running task ${task.name}...`);
+                        childCtx.log.info(dictionary("app.domain.entities.routine.runningTask", this.getTaskDisplayName(task)));
                         await task.run({ abortSignal, runCtx: childCtx });
-                        childCtx.log.info(`Task ${task.name} completed`);
+                        childCtx.log.info(dictionary("app.domain.entities.routine.taskCompleted", this.getTaskDisplayName(task)));
                     } catch (e) {
                         if (abortSignal.aborted) {
-                            childCtx.log.warn(`Task ${task.name} aborted: ${abortSignal.reason}`);
+                            childCtx.log.warn(dictionary("app.domain.entities.routine.taskAborted", this.getTaskDisplayName(task), String(abortSignal.reason)));
                             this.#setStatus("aborted");
-                            throw new Error(`Routine aborted: ${abortSignal.reason}`);
+                            throw new Error(dictionary("app.domain.entities.routine.aborted", String(abortSignal.reason ?? "")));
                         }
                         if (this.continueOnError) {
-                            childCtx.log.warn(`Task failed: ${e?.message || e}`);
+                            childCtx.log.warn(dictionary("app.domain.entities.routine.taskFailed", this.getTaskDisplayName(task), e?.message || String(e)));
                             this.#setStatus("failed");
                         } else {
                             this.#setStatus("failed");
-                            throw new Error("Task failed. Breaking execution 'Continue on error' is disabled");
+                            throw new Error(dictionary("app.domain.entities.routine.breakOnErrorDisabled"));
                         }
                     }
                 }
@@ -448,16 +459,16 @@ export class Routine extends EventEmitter implements RoutineInterface {
             const runInParallelBreakOnError = async (abortSignal: AbortSignal) => {
                 return new Promise<void>(async (resolve, reject) => {
 
-                    this.logger.info(childCtx.log.info("Running tasks in parallel without continueOnError..."));
+                    this.logger.info(childCtx.log.info(dictionary("app.domain.entities.routine.runningTasksInParallelBreak")));
                     try {
-                        const result = await Promise.all(this.tasks.map(task => task.run({ abortSignal, runCtx: childCtx })))
-                        childCtx.log.info(`Tasks completed: ${result}`);
+                        const result = await Promise.all(this.tasks.map(task => task.run({ abortSignal, runCtx: childCtx })));
+                        childCtx.log.info(dictionary("app.domain.entities.routine.tasksCompletedWithResult", JSON.stringify(result)));
                         resolve();
                     } catch (e) {
                         if (abortSignal.aborted) {
-                            childCtx.log.warn(`Tasks aborted: ${abortSignal.reason}`);
+                            childCtx.log.warn(dictionary("app.domain.entities.routine.tasksAborted", String(abortSignal.reason)));
                             this.#setStatus("aborted");
-                            return reject(new Error(`Routine aborted: ${abortSignal.reason}`));
+                            return reject(new Error(dictionary("app.domain.entities.routine.aborted", String(abortSignal.reason ?? ""))));
                         }
                         this.#setStatus("failed");
                         return reject(e);
@@ -468,24 +479,25 @@ export class Routine extends EventEmitter implements RoutineInterface {
             const runInParallelContinueOnError = async (abortSignal: AbortSignal) => {
 
                 return new Promise<void>(async (resolve, reject) => {
-                    this.logger.info(childCtx.log.info("Running tasks in parallel with continueOnError..."));
+                    this.logger.info(childCtx.log.info(dictionary("app.domain.entities.routine.runningTasksInParallelContinue")));
 
-                    const result = await Promise.allSettled(this.tasks.map(task => task.run({ abortSignal, runCtx: childCtx })))
+                    const result = await Promise.allSettled(this.tasks.map(task => task.run({ abortSignal, runCtx: childCtx })));
 
                     if (result.every((res) => res.status === 'fulfilled')) {
-                        childCtx.log.info(`Tasks completed: ${this.getTasks().map(task => task.name).join(', ')}`);
+                        const completedTaskNames = this.getTasks().map(task => this.getTaskDisplayName(task)).join(', ');
+                        childCtx.log.info(dictionary("app.domain.entities.routine.tasksCompletedList", completedTaskNames));
                         this.#setStatus("completed");
                         resolve();
                     } else {
                         for (const res of result) {
                             if (res.status === 'rejected') {
-                                childCtx.log.warn(`Task failed: ${res.reason}`);
+                                childCtx.log.warn(dictionary("app.domain.entities.routine.taskFailedReason", String(res.reason)));
                             } else {
-                                childCtx.log.info(`Task completed: ${res.value}`);
+                                childCtx.log.info(dictionary("app.domain.entities.routine.taskFulfilledValue", String(res.value)));
                             }
                         }
                         this.#setStatus("failed");
-                        reject("Some tasks failed. Check logs for details")
+                        reject(new Error(dictionary("app.domain.entities.routine.tasksFailedDetails")))
                     }
                 })
             }
@@ -501,7 +513,7 @@ export class Routine extends EventEmitter implements RoutineInterface {
 
             //handler to abort tasks when routine is aborted or timeout occurs
             const handleOnAbortExecution = () => {
-                abortTasksController.abort("Routine aborted");
+                abortTasksController.abort(dictionary("app.domain.entities.routine.abortSignal"));
             }
 
             userAbortSignal.addEventListener("abort", handleOnAbortExecution);
@@ -527,7 +539,7 @@ export class Routine extends EventEmitter implements RoutineInterface {
                         ]);
 
                 this.#setStatus("completed")
-                this.logger.info(childCtx.log.info(`Routine completed successfully in ${Date.now() - routineStartTime}ms`));
+                this.logger.info(childCtx.log.info(dictionary("app.domain.entities.routine.completed", Date.now() - routineStartTime)));
                 this.#eventDispatcher(routineEvents.routineCompleted);
 
                 resolve();
@@ -535,15 +547,15 @@ export class Routine extends EventEmitter implements RoutineInterface {
 
                     if (userAbortSignal.aborted) {
                         this.#setStatus("aborted");
-                        this.logger.warn(childCtx.log.warn(`Routine aborted by user: ${e?.message || e}`))
+                    this.logger.warn(childCtx.log.warn(dictionary("app.domain.entities.routine.aborted", e?.message || String(e))));
                         this.#eventDispatcher(routineEvents.routineAborted);
                     } else if (this.timeoutController?.timedout) {
-                        this.logger.warn(childCtx.log.warn(`Routine timed out: ${e?.message || e}`))
+                    this.logger.warn(childCtx.log.warn(dictionary("app.domain.entities.routine.timedOut", e?.message || String(e))));
                         this.#eventDispatcher(routineEvents.routineTimeout);
                         this.#setStatus("timedout");
                     } else {
                         this.#setStatus("failed");
-                        this.logger.error(childCtx.log.error(`Routine ended with error: ${e?.message || e}`))
+                    this.logger.error(childCtx.log.error(dictionary("app.domain.entities.routine.failed", e?.message || String(e))));
                         this.#eventDispatcher(routineEvents.routineFailed);
                     }
 

--- a/src/app/src/domain/entities/trigger/index.ts
+++ b/src/app/src/domain/entities/trigger/index.ts
@@ -3,6 +3,8 @@ import { requiredTriggerParamType, TriggerInterface, TriggerType } from "@common
 import { Log } from "@src/utils/log";
 import triggerEvents from "@common/events/trigger.events";
 import { Context } from "../context";
+import dictionary from "@common/i18n";
+import crypto from "crypto";
 
 export class Trigger extends EventEmitter implements TriggerInterface {
     id: TriggerInterface["id"];
@@ -91,26 +93,26 @@ export class Trigger extends EventEmitter implements TriggerInterface {
 
         const origin = {
             type: "trigger",
-            id: this.id, name:
-                this.name
+            id: this.id,
+            name: this.name
         }
         const ctx = Context.createRootContext(origin);
 
         this.triggered = true;
         this.dispatchEvent(triggerEvents.triggered, { ctx });
         this.logger.info(`${this.type.charAt(0).toUpperCase() + this.type.slice(1).toLowerCase()} trigger triggered [ctx: ${ctx.id}]`);
-        ctx.log.info("Trigger activated");
+        ctx.log.info(dictionary("app.domain.entities.trigger.activated", this.getDisplayName()));
         this.disarm();
-        ctx.log.info("Trigger disarmed");
+        ctx.log.info(dictionary("app.domain.entities.trigger.disarmed", this.getDisplayName()));
 
         if (!this.reArmOnTrigger)
             return
 
-        if (!this.allowAutoRearming) 
+        if (!this.allowAutoRearming)
             return;
-        
+
         this.arm();
-        ctx.log.info("Trigger rearmed automatically");
+        ctx.log.info(dictionary("app.domain.entities.trigger.rearmed", this.getDisplayName()));
 
     }
 
@@ -148,6 +150,10 @@ export class Trigger extends EventEmitter implements TriggerInterface {
             params: this.params,
             type: this.type
         };
+    }
+
+    private getDisplayName(): string {
+        return this.name || this.id;
     }
 
 }

--- a/src/common/i18n/index.ts
+++ b/src/common/i18n/index.ts
@@ -1,32 +1,203 @@
-
 const LANG = String(process.env.DEFAULT_LANGUAGE || "es");
 
-
-export const dictionary = (key: string, ...params: any[]): string => {    
-    let translation = translations[LANG][key] || key;
-    if (params) {
+export const dictionary = (key: string, ...params: Array<string | number>): string => {
+    const translationsForLang = translations[LANG] ?? translations.es;
+    let translation = translationsForLang[key] || key;
+    if (params.length > 0) {
         params.forEach((param, index) => {
-            translation = translation.replace(`{${index + 1}}`, param);
+            translation = translation.replace(`{${index + 1}}`, String(param));
         });
     }
     return translation;
-}
+};
 
 const translations: { [key: string]: { [key: string]: string } } = {
     es: {
         "app.domain.entities.job.executed": "Se ejecutó el trabajo '{1}'",
-        "app.domain.entities.job.aborted": "La ejecución del trabajo fue abortada.",
-        "app.domain.entities.job.abortedByUser": "La ejecución del trabajo '{%1}' fue abortada por el usuario.",
-        "app.domain.entities.job.failed": "La ejecución del trabajo falló: {%1}",
-        "app.domain.entities.job.finished": "La ejecución del trabajo ha finalizado exitosamente en {%1} ms.",
+        "app.domain.entities.job.aborted": "La ejecución del trabajo '{1}' fue abortada.",
+        "app.domain.entities.job.abortedByUser": "La ejecución del trabajo '{1}' fue abortada por el usuario.",
+        "app.domain.entities.job.failed": "La ejecución del trabajo falló: {1}",
+        "app.domain.entities.job.finished": "La ejecución del trabajo ha finalizado exitosamente en {1} ms.",
+
+        "app.domain.entities.job.wait.invalidTimeParameter": "Parámetro 'time' inválido para el trabajo '{1}': {2}",
+        "app.domain.entities.job.contextRequired": "Se requiere un contexto para ejecutar el trabajo '{1}'",
+        "app.domain.entities.job.abortSignalRequired": "Se requiere un AbortSignal para ejecutar el trabajo '{1}'",
+        "app.domain.entities.job.wait.aborted": "Se abortó el trabajo '{1}'",
+        "app.domain.entities.job.wait.completed": "El trabajo '{1}' se completó correctamente",
+
+        "app.domain.entities.job.sendUdp.starting": "Iniciando el trabajo '{1}'",
+        "app.domain.entities.job.sendUdp.sendingToBroadcast": "Enviando paquete UDP a la dirección de broadcast {1}:{2}",
+        "app.domain.entities.job.sendUdp.failed": "Error al enviar el paquete UDP: {1}",
+        "app.domain.entities.job.sendUdp.sent": "Paquete UDP '{1}' enviado a {2}:{3}",
+        "app.domain.entities.job.sendUdp.finished": "El trabajo '{1}' ha finalizado",
+
+        "app.domain.entities.job.sendTcp.failed": "Error al enviar el paquete TCP: {1}",
+        "app.domain.entities.job.sendTcp.sent": "Paquete TCP enviado a {1}:{2}",
+
+        "app.domain.entities.job.wakeOnLan.starting": "Iniciando el trabajo '{1}'",
+        "app.domain.entities.job.wakeOnLan.failed": "Error al enviar el paquete UDP: {1}",
+        "app.domain.entities.job.wakeOnLan.sent": "Paquete UDP para despertar el dispositivo con MAC '{1}' enviado al puerto {2}",
+        "app.domain.entities.job.wakeOnLan.finished": "El trabajo '{1}' ha finalizado",
+
+        "app.domain.entities.job.sendPjLink.starting": "Iniciando comando PJLink {1} hacia {2}",
+        "app.domain.entities.job.sendPjLink.completed": "Comando PJLink completado correctamente en {1}",
+        "app.domain.entities.job.sendPjLink.unknownCommand": "Comando PJLink desconocido: {1}",
+        "app.domain.entities.job.sendPjLink.timeout": "Tiempo de espera agotado al comunicarse con el dispositivo PJLink",
+        "app.domain.entities.job.sendPjLink.authRequired": "El dispositivo requiere autenticación PJLink",
+
+        "app.domain.entities.trigger.activated": "El disparador '{1}' se activó",
+        "app.domain.entities.trigger.disarmed": "El disparador '{1}' se desarmó",
+        "app.domain.entities.trigger.rearmed": "El disparador '{1}' se rearma automáticamente",
+
+        "app.domain.entities.condition.evaluationSucceeded": "La evaluación de la condición '{1}' fue exitosa",
+        "app.domain.entities.condition.evaluationFailed": "Error durante la evaluación de la condición '{1}': {2}",
+        "app.domain.entities.condition.pingFailed": "La verificación de la condición '{1}' falló: destino inaccesible",
+        "app.domain.entities.condition.pjlinkUnknownStatus": "Estado PJLink desconocido: {1}",
+        "app.domain.entities.condition.pjlinkTimeout": "Tiempo de espera agotado al consultar el dispositivo PJLink",
+        "app.domain.entities.condition.pjlinkAuthRequired": "El dispositivo PJLink requiere autenticación",
+        "app.domain.entities.condition.pjlinkErrorResponse": "Respuesta de error del dispositivo PJLink: {1}",
+
+        "app.domain.entities.routine.notEnabled": "La rutina '{1}' no está habilitada",
+        "app.domain.entities.routine.invalidTrigger": "La rutina '{1}' no tiene un disparador válido",
+        "app.domain.entities.routine.alreadyRunning": "La rutina '{1}' ya se está ejecutando",
+        "app.domain.entities.routine.invalidContext": "Se proporcionó un contexto inválido para la rutina '{1}'",
+        "app.domain.entities.routine.autoCheckingConditions": "Autoverificando condiciones para {1} tareas",
+        "app.domain.entities.routine.checkingConditionForTask": "Verificando condición para la tarea '{1}'",
+        "app.domain.entities.routine.started": "La rutina '{1}' inició",
+        "app.domain.entities.routine.runningTasksInSync": "Ejecutando tareas en secuencia...",
+        "app.domain.entities.routine.runningTask": "Ejecutando la tarea '{1}'...",
+        "app.domain.entities.routine.taskCompleted": "La tarea '{1}' finalizó",
+        "app.domain.entities.routine.taskAborted": "La tarea '{1}' fue abortada: {2}",
+        "app.domain.entities.routine.taskFailed": "La tarea '{1}' falló: {2}",
+        "app.domain.entities.routine.runningTasksInParallelBreak": "Ejecutando tareas en paralelo sin 'continuar en error'...",
+        "app.domain.entities.routine.tasksCompletedWithResult": "Tareas completadas: {1}",
+        "app.domain.entities.routine.tasksAborted": "Tareas abortadas: {1}",
+        "app.domain.entities.routine.runningTasksInParallelContinue": "Ejecutando tareas en paralelo con 'continuar en error'...",
+        "app.domain.entities.routine.tasksCompletedList": "Tareas completadas: {1}",
+        "app.domain.entities.routine.taskFailedReason": "La tarea falló: {1}",
+        "app.domain.entities.routine.taskFulfilledValue": "La tarea completó: {1}",
+        "app.domain.entities.routine.completed": "La rutina finalizó correctamente en {1} ms",
+        "app.domain.entities.routine.aborted": "La rutina fue abortada: {1}",
+        "app.domain.entities.routine.timedOut": "La rutina alcanzó el tiempo máximo: {1}",
+        "app.domain.entities.routine.failed": "La rutina finalizó con errores: {1}",
+        "app.domain.entities.routine.breakOnErrorDisabled": "La tarea falló. Se detiene la ejecución porque 'continuar en error' está deshabilitado.",
+        "app.domain.entities.routine.tasksFailedDetails": "Algunas tareas fallaron. Verifica los registros para más detalles.",
+        "app.domain.entities.routine.abortSignal": "Señal de aborto recibida",
+
+        "app.domain.entities.task.starting": "Iniciando la tarea '{1}'",
+        "app.domain.entities.task.aborted": "La tarea '{1}' fue abortada",
+        "app.domain.entities.task.timedOut": "La tarea '{1}' excedió el tiempo máximo",
+        "app.domain.entities.task.failed": "La tarea '{1}' falló: {2}",
+        "app.domain.entities.task.completed": "La tarea '{1}' finalizó correctamente en {2} ms",
+        "app.domain.entities.task.conditionMet": "La condición de la tarea '{1}' se cumplió, finalizando ejecución",
+        "app.domain.entities.task.checkingConditionBefore": "Verificando condición antes de ejecutar la tarea '{1}'",
+        "app.domain.entities.task.executingJobAttempt": "Ejecutando el trabajo de la tarea '{1}', intento {2} de {3}",
+        "app.domain.entities.task.noCondition": "La tarea '{1}' no tiene condición, finalizando ejecución",
+        "app.domain.entities.task.conditionNotMetAfter": "La condición de la tarea '{1}' no se cumplió tras ejecutar el trabajo, se reintenta",
+        "app.domain.entities.task.abortedNotContinuing": "La tarea '{1}' fue abortada, no se continúa",
+        "app.domain.entities.task.error": "Error en la tarea '{1}': {2}",
+        "app.domain.entities.task.failedNoContinue": "La tarea '{1}' falló y no continuará porque 'continuar en error' está deshabilitado",
+        "app.domain.entities.task.maxRetries": "Se alcanzó el máximo de reintentos para la tarea '{1}'",
+        "app.domain.entities.task.retrying": "Reintentando la tarea '{1}' en {2} ms",
+        "app.domain.entities.task.abortedDuringRetryWait": "La tarea '{1}' fue abortada durante la espera para reintentar.",
+        "app.domain.entities.task.noJobConfigured": "No hay un trabajo válido configurado para la tarea '{1}'",
+
+        "app.domain.entities.condition.evaluationAborted": "La evaluación de la condición '{1}' fue abortada.",
+        "app.domain.entities.condition.notMet": "La condición '{1}' no se cumplió.",
     },
     en: {
         "app.domain.entities.job.executed": "Job '{1}' executed",
-        "app.domain.entities.job.aborted": "Job execution was aborted.",
-        "app.domain.entities.job.abortedByUser": "Job '{%1}' execution was aborted by the user.",
-        "app.domain.entities.job.failed": "Job execution failed: {%1}",
-        "app.domain.entities.job.finished": "Job execution finished successfully in {%1} ms."
+        "app.domain.entities.job.aborted": "Job '{1}' execution was aborted.",
+        "app.domain.entities.job.abortedByUser": "Job '{1}' execution was aborted by the user.",
+        "app.domain.entities.job.failed": "Job execution failed: {1}",
+        "app.domain.entities.job.finished": "Job execution finished successfully in {1} ms.",
+
+        "app.domain.entities.job.wait.invalidTimeParameter": "Invalid 'time' parameter for job '{1}': {2}",
+        "app.domain.entities.job.contextRequired": "Context is required to execute job '{1}'",
+        "app.domain.entities.job.abortSignalRequired": "AbortSignal is required to execute job '{1}'",
+        "app.domain.entities.job.wait.aborted": "Job '{1}' was aborted",
+        "app.domain.entities.job.wait.completed": "Job '{1}' completed successfully",
+
+        "app.domain.entities.job.sendUdp.starting": "Starting job '{1}'",
+        "app.domain.entities.job.sendUdp.sendingToBroadcast": "Sending UDP packet to broadcast address {1}:{2}",
+        "app.domain.entities.job.sendUdp.failed": "Failed to send UDP packet: {1}",
+        "app.domain.entities.job.sendUdp.sent": "UDP packet '{1}' sent to {2}:{3}",
+        "app.domain.entities.job.sendUdp.finished": "Job '{1}' has finished",
+
+        "app.domain.entities.job.sendTcp.failed": "Failed to send TCP packet: {1}",
+        "app.domain.entities.job.sendTcp.sent": "TCP packet sent to {1}:{2}",
+
+        "app.domain.entities.job.wakeOnLan.starting": "Starting job '{1}'",
+        "app.domain.entities.job.wakeOnLan.failed": "Failed to send UDP packet: {1}",
+        "app.domain.entities.job.wakeOnLan.sent": "UDP packet to wake device with MAC '{1}' sent to port {2}",
+        "app.domain.entities.job.wakeOnLan.finished": "Job '{1}' has finished",
+
+        "app.domain.entities.job.sendPjLink.starting": "Starting PJLink command {1} to {2}",
+        "app.domain.entities.job.sendPjLink.completed": "PJLink command completed successfully in {1}",
+        "app.domain.entities.job.sendPjLink.unknownCommand": "Unknown PJLink command: {1}",
+        "app.domain.entities.job.sendPjLink.timeout": "Timeout while communicating with the PJLink device",
+        "app.domain.entities.job.sendPjLink.authRequired": "The device requires PJLink authentication",
+
+        "app.domain.entities.trigger.activated": "Trigger '{1}' activated",
+        "app.domain.entities.trigger.disarmed": "Trigger '{1}' disarmed",
+        "app.domain.entities.trigger.rearmed": "Trigger '{1}' rearmed automatically",
+
+        "app.domain.entities.condition.evaluationSucceeded": "Condition '{1}' evaluation succeeded",
+        "app.domain.entities.condition.evaluationFailed": "Error during condition '{1}' evaluation: {2}",
+        "app.domain.entities.condition.pingFailed": "Condition '{1}' check failed: destination unreachable",
+        "app.domain.entities.condition.pjlinkUnknownStatus": "Unknown PJLink status: {1}",
+        "app.domain.entities.condition.pjlinkTimeout": "Timeout while querying the PJLink device",
+        "app.domain.entities.condition.pjlinkAuthRequired": "PJLink device requires authentication",
+        "app.domain.entities.condition.pjlinkErrorResponse": "PJLink device returned an error response: {1}",
+
+        "app.domain.entities.routine.notEnabled": "Routine '{1}' is not enabled",
+        "app.domain.entities.routine.invalidTrigger": "Routine '{1}' is not triggered by a valid trigger",
+        "app.domain.entities.routine.alreadyRunning": "Routine '{1}' is already running",
+        "app.domain.entities.routine.invalidContext": "An invalid context was provided for routine '{1}'",
+        "app.domain.entities.routine.autoCheckingConditions": "Autochecking conditions for {1} tasks",
+        "app.domain.entities.routine.checkingConditionForTask": "Checking condition for task '{1}'",
+        "app.domain.entities.routine.started": "Routine '{1}' started",
+        "app.domain.entities.routine.runningTasksInSync": "Running tasks in sync...",
+        "app.domain.entities.routine.runningTask": "Running task '{1}'...",
+        "app.domain.entities.routine.taskCompleted": "Task '{1}' completed",
+        "app.domain.entities.routine.taskAborted": "Task '{1}' aborted: {2}",
+        "app.domain.entities.routine.taskFailed": "Task '{1}' failed: {2}",
+        "app.domain.entities.routine.runningTasksInParallelBreak": "Running tasks in parallel without continueOnError...",
+        "app.domain.entities.routine.tasksCompletedWithResult": "Tasks completed: {1}",
+        "app.domain.entities.routine.tasksAborted": "Tasks aborted: {1}",
+        "app.domain.entities.routine.runningTasksInParallelContinue": "Running tasks in parallel with continueOnError...",
+        "app.domain.entities.routine.tasksCompletedList": "Tasks completed: {1}",
+        "app.domain.entities.routine.taskFailedReason": "Task failed: {1}",
+        "app.domain.entities.routine.taskFulfilledValue": "Task completed: {1}",
+        "app.domain.entities.routine.completed": "Routine completed successfully in {1} ms",
+        "app.domain.entities.routine.aborted": "Routine was aborted: {1}",
+        "app.domain.entities.routine.timedOut": "Routine timed out: {1}",
+        "app.domain.entities.routine.failed": "Routine ended with error: {1}",
+        "app.domain.entities.routine.breakOnErrorDisabled": "Task failed. Breaking execution because 'Continue on error' is disabled.",
+        "app.domain.entities.routine.tasksFailedDetails": "Some tasks failed. Check logs for details.",
+        "app.domain.entities.routine.abortSignal": "Abort signal received",
+
+        "app.domain.entities.task.starting": "Starting task '{1}'",
+        "app.domain.entities.task.aborted": "Task '{1}' aborted",
+        "app.domain.entities.task.timedOut": "Task '{1}' timed out",
+        "app.domain.entities.task.failed": "Task '{1}' failed: {2}",
+        "app.domain.entities.task.completed": "Task '{1}' completed successfully in {2} ms",
+        "app.domain.entities.task.conditionMet": "Condition met for task '{1}', finishing execution",
+        "app.domain.entities.task.checkingConditionBefore": "Checking condition before executing task '{1}'",
+        "app.domain.entities.task.executingJobAttempt": "Executing job for task '{1}', attempt {2} of {3}",
+        "app.domain.entities.task.noCondition": "No condition set for task '{1}', finishing execution",
+        "app.domain.entities.task.conditionNotMetAfter": "Condition not met for task '{1}' after job execution, will retry",
+        "app.domain.entities.task.abortedNotContinuing": "Task '{1}' aborted, not continuing",
+        "app.domain.entities.task.error": "Error in task '{1}': {2}",
+        "app.domain.entities.task.failedNoContinue": "Task '{1}' failed and will not continue because continueOnError is false",
+        "app.domain.entities.task.maxRetries": "Max retries reached for task '{1}'",
+        "app.domain.entities.task.retrying": "Retrying task '{1}' in {2} ms",
+        "app.domain.entities.task.abortedDuringRetryWait": "Task '{1}' was aborted during the retry wait.",
+        "app.domain.entities.task.noJobConfigured": "No valid job configured for task '{1}'",
+
+        "app.domain.entities.condition.evaluationAborted": "Condition '{1}' evaluation was aborted.",
+        "app.domain.entities.condition.notMet": "Condition '{1}' was not met.",
     }
-}
+};
 
 export default dictionary;


### PR DESCRIPTION
## Summary
- localize promise rejection messages emitted by routines, tasks, jobs, and conditions so context logs surface translated text
- expand the shared i18n dictionary with abort, timeout, and protocol-specific messages and reuse display names instead of IDs
- update job and condition implementations to propagate localized errors and reuse shared helpers when rejecting promises

## Testing
- npm test *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68d953b268dc83279857f02f72affcb1