### PR TITLE
Sort routine executions by timestamp

### DIFF
--- a/src/app/src/services/ipcServices/executions.services.ts
+++ b/src/app/src/services/ipcServices/executions.services.ts
@@ -43,6 +43,7 @@ const getExecutionsList = async ({ routineId }: { routineId: string }, callback:
 
         if (routineId) {
             executions = await getRoutineExecutions(routineId);
+            executions.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
             callback(executions);
         } else {
             callback({ error: "Routine ID is required to fetch executions." });


### PR DESCRIPTION
## Summary
- ensure routine executions fetched via IPC are sorted by their timestamp in descending order

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d95da9a3008327abde2b5c8e20daf2