### PR TITLE
feat: add licensing service and generator script

### DIFF
--- a/scripts/generate-license.js
+++ b/scripts/generate-license.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+const { createHmac } = require("node:crypto");
+const { createInterface } = require("node:readline/promises");
+const { stdin, stdout, exit } = require("node:process");
+
+const LICENSE_SECRET = process.env.LICENSE_SECRET ?? "devicecontrol-license-secret";
+
+const base64UrlEncode = (value) => Buffer.from(value).toString("base64url");
+
+const generateLicenseKey = (fingerprint, durationDays) => {
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + durationDays * 24 * 60 * 60 * 1000);
+
+  const payload = {
+    fingerprint,
+    issuedAt: now.toISOString(),
+    expiresAt: expiresAt.toISOString(),
+  };
+
+  const data = base64UrlEncode(JSON.stringify(payload));
+  const signature = createHmac("sha256", LICENSE_SECRET)
+    .update(data)
+    .digest("base64url");
+
+  return `${data}.${signature}`;
+};
+
+const main = async () => {
+  const rl = createInterface({ input: stdin, output: stdout });
+
+  try {
+    const fingerprint = (await rl.question("System fingerprint: ")).trim();
+
+    if (!fingerprint) {
+      console.error("Fingerprint is required");
+      exit(1);
+    }
+
+    const defaultDuration = 365;
+    const durationAnswer = (await rl.question(`License duration in days (default ${defaultDuration}): `)).trim();
+    const durationDays = durationAnswer ? Number.parseInt(durationAnswer, 10) : defaultDuration;
+
+    if (!Number.isFinite(durationDays) || durationDays <= 0) {
+      console.error("Duration must be a positive integer");
+      exit(1);
+    }
+
+    const licenseKey = generateLicenseKey(fingerprint, durationDays);
+
+    console.log("\nLicense generated successfully!\n");
+    console.log(`Fingerprint: ${fingerprint}`);
+    console.log(`Valid for: ${durationDays} day(s)`);
+    console.log("License key:\n");
+    console.log(licenseKey);
+  } finally {
+    rl.close();
+  }
+};
+
+main().catch((error) => {
+  console.error("Failed to generate license", error);
+  exit(1);
+});

--- a/src/app/src/services/licensing/index.ts
+++ b/src/app/src/services/licensing/index.ts
@@ -1,0 +1,207 @@
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
+import { execSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { getUserDataPath } from "@utils/paths";
+
+const LICENSE_SECRET = process.env.LICENSE_SECRET ?? "devicecontrol-license-secret";
+const LICENSE_FILENAME = "license.json";
+
+type LicensePayload = {
+  fingerprint: string;
+  issuedAt: string;
+  expiresAt: string;
+};
+
+type StoredLicense = {
+  licenseKey: string;
+};
+
+const base64UrlDecode = (value: string): string =>
+  Buffer.from(value, "base64url").toString("utf8");
+
+const parseLicenseKey = (licenseKey: string): LicensePayload | null => {
+  const [data, signature] = licenseKey.split(".");
+
+  if (!data || !signature) {
+    return null;
+  }
+
+  const expectedSignature = createHmac("sha256", LICENSE_SECRET)
+    .update(data)
+    .digest("base64url");
+
+  const provided = Buffer.from(signature);
+  const expected = Buffer.from(expectedSignature);
+
+  if (provided.length !== expected.length || !timingSafeEqual(provided, expected)) {
+    return null;
+  }
+
+  try {
+    const parsed: LicensePayload = JSON.parse(base64UrlDecode(data));
+    return parsed;
+  } catch {
+    return null;
+  }
+};
+
+const getLicenseFilePath = async (): Promise<string> => {
+  const userDataPath = await getUserDataPath();
+  return path.join(userDataPath, LICENSE_FILENAME);
+};
+
+const readFileIfExists = async (filePath: string): Promise<string | null> => {
+  try {
+    const content = await fs.readFile(filePath, "utf8");
+    return content;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+};
+
+const getMachineIdentifier = async (): Promise<string> => {
+  const platform = os.platform();
+
+  if (platform === "win32") {
+    try {
+      const output = execSync("wmic csproduct get uuid", { stdio: ["ignore", "pipe", "ignore"] })
+        .toString()
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean);
+
+      if (output.length > 1) {
+        return output[1];
+      }
+    } catch {
+      // Ignore errors and fallback to generic identifiers
+    }
+  }
+
+  if (platform === "linux") {
+    const candidates = ["/etc/machine-id", "/var/lib/dbus/machine-id"];
+
+    for (const file of candidates) {
+      try {
+        const content = await fs.readFile(file, "utf8");
+        const sanitized = content.trim();
+        if (sanitized) {
+          return sanitized;
+        }
+      } catch {
+        // Try next candidate
+      }
+    }
+  }
+
+  if (platform === "darwin") {
+    try {
+      const output = execSync("ioreg -rd1 -c IOPlatformExpertDevice | awk '/IOPlatformUUID/ { print $3; }'", {
+        stdio: ["ignore", "pipe", "ignore"],
+        shell: "/bin/bash",
+      })
+        .toString()
+        .trim()
+        .replace(/\"/g, "");
+
+      if (output) {
+        return output;
+      }
+    } catch {
+      // Ignore errors and fallback to generic identifiers
+    }
+  }
+
+  const genericId = [os.hostname(), os.arch(), os.type(), os.release()].join("-");
+  return genericId;
+};
+
+const buildFingerprintSeed = async (): Promise<string> => {
+  const machineId = await getMachineIdentifier();
+  const cpus = os.cpus() ?? [];
+  const primaryCpu = cpus[0]?.model ?? "unknown";
+  const macAddresses = Object.values(os.networkInterfaces())
+    .flatMap((ifaces) => ifaces ?? [])
+    .filter((iface) => !iface.internal)
+    .map((iface) => iface.mac)
+    .sort()
+    .join(";");
+
+  return [
+    machineId,
+    os.platform(),
+    os.release(),
+    os.arch(),
+    primaryCpu,
+    os.totalmem().toString(),
+    macAddresses,
+  ].join("|");
+};
+
+export const getSystemFingerprint = async (): Promise<string> => {
+  const seed = await buildFingerprintSeed();
+  const hash = createHash("sha256");
+  hash.update(seed);
+  return hash.digest("hex");
+};
+
+const validateLicense = async (licenseKey: string): Promise<LicensePayload | null> => {
+  const payload = parseLicenseKey(licenseKey);
+  if (!payload) {
+    return null;
+  }
+
+  const fingerprint = await getSystemFingerprint();
+  if (payload.fingerprint !== fingerprint) {
+    return null;
+  }
+
+  if (Date.now() > new Date(payload.expiresAt).getTime()) {
+    return null;
+  }
+
+  return payload;
+};
+
+export const setSystemLicense = async (licenseKey: string): Promise<boolean> => {
+  const payload = await validateLicense(licenseKey);
+
+  if (!payload) {
+    return false;
+  }
+
+  const filePath = await getLicenseFilePath();
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+
+  const storedLicense: StoredLicense = {
+    licenseKey,
+  };
+
+  await fs.writeFile(filePath, JSON.stringify(storedLicense, null, 2), "utf8");
+  return true;
+};
+
+export const checkLicense = async (): Promise<boolean> => {
+  const filePath = await getLicenseFilePath();
+  const content = await readFileIfExists(filePath);
+
+  if (!content) {
+    return false;
+  }
+
+  try {
+    const stored: StoredLicense = JSON.parse(content);
+    const payload = await validateLicense(stored.licenseKey);
+    return payload !== null;
+  } catch {
+    return false;
+  }
+};
+
+export const decodeLicenseForDebug = (licenseKey: string): LicensePayload | null => parseLicenseKey(licenseKey);


### PR DESCRIPTION
## Summary
- add a licensing service that builds a system fingerprint, validates license keys, and persists them to user data storage
- add a Node.js CLI script for generating signed license keys from fingerprints

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68def68d955c8327935ae36215ff1825